### PR TITLE
Add docker environment with documentation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,39 @@
+FROM ruby:2.6
+
+# Add yarn debian source to apt
+RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -
+RUN echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list
+
+# Add chrome debian source to apt
+RUN curl -sS https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add -
+RUN echo "deb [arch=amd64]  http://dl.google.com/linux/chrome/deb/ stable main" | tee /etc/apt/sources.list.d/google-chrome.list
+
+# Install Chromedriver
+RUN wget https://chromedriver.storage.googleapis.com/2.41/chromedriver_linux64.zip && \
+    unzip chromedriver_linux64.zip -d /usr/bin && \
+    chmod u+x /usr/bin/chromedriver
+
+RUN apt-get update -qq && apt-get install -y nodejs postgresql-client yarn google-chrome-stable
+RUN gem install bundler -v 2.1.4
+
+RUN mkdir /app
+WORKDIR /app
+
+COPY Gemfile /app/Gemfile
+COPY Gemfile.lock /app/Gemfile.lock
+RUN bundle install
+
+COPY package.json /app/package.json
+COPY yarn.lock /app/yarn.lock
+RUN yarn install
+
+COPY . /app
+
+# Add a script to be executed every time the container starts.
+COPY entrypoint.sh /usr/bin/
+RUN chmod +x /usr/bin/entrypoint.sh
+ENTRYPOINT ["entrypoint.sh"]
+EXPOSE 3000
+
+# Start the main process.
+CMD ["rails", "server", "-b", "0.0.0.0"]

--- a/README.md
+++ b/README.md
@@ -7,7 +7,11 @@ Jam Roulette is a Rails (+ React, Typescript) application for layered jamming an
 
 ### Docker
 
-TODO
+Build the image with `docker-compose build` (the first time building will take the longest)
+
+To run the server, `docker-compose up` and point your browser to [http://localhost:3000](lhttp://localhost:3000)
+
+To just run the test suite, `docker-compose run web rake`
 
 ### Running locally
 

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -12,6 +12,8 @@ Rails.application.configure do
   # Show full error reports.
   config.consider_all_requests_local = true
 
+  config.webpacker.check_yarn_integrity = false
+
   # Enable/disable caching. By default caching is disabled.
   # Run rails dev:cache to toggle caching.
   if Rails.root.join('tmp', 'caching-dev.txt').exist?

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,15 @@
+version: '3'
+services:
+  # db:
+  #   image: postgres
+  #   volumes:
+  #     - ./tmp/db:/var/lib/postgresql/data
+  web:
+    build: .
+    command: bash -c "rm -f tmp/pids/server.pid && bundle exec rails s -p 3000 -b '0.0.0.0'"
+    volumes:
+      - .:/app
+    ports:
+      - "3000:3000"
+    # depends_on:
+    #   - db

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+set -e
+
+# Remove a potentially pre-existing server.pid for Rails.
+rm -f /app/tmp/pids/server.pid
+
+# Then exec the container's main process (what's set as CMD in the Dockerfile).
+exec "$@"


### PR DESCRIPTION
Adds a Dockerfile that:

1. Installs yarn
2. Installs chrome + chromedriver (for headless system tests)
3. Runs bundle and yarn installs
4. Runs the server

The `docker-compose.yml` file defines a web service and in the comments I left the postgres service in the event that we migrate to postgres (I see this happening in the future but not quite yet).

I needed to disable `config.webpacker.check_yarn_integrity` in the development environment, otherwise, the server refused to run because it would fail the integrity check.