### PR TITLE
Upgrade nokogiri to 1.10.9

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -101,7 +101,7 @@ GEM
     minitest (5.14.0)
     msgpack (1.3.1)
     nio4r (2.5.2)
-    nokogiri (1.10.7)
+    nokogiri (1.10.9)
       mini_portile2 (~> 2.4.0)
     public_suffix (4.0.3)
     puma (4.3.3)


### PR DESCRIPTION
Current version contains a known security vulnerability.