### PR TITLE
Change room_hash to public_id on the Room model

### DIFF
--- a/app/controllers/jams_controller.rb
+++ b/app/controllers/jams_controller.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
 class JamsController < ApplicationController
-  # POST /rooms/:room_hash/jams
+  # POST /rooms/:public_id/jams
   def create
-    room = Room.find_by!(room_hash: params[:room_id])
+    room = Room.find_by!(public_id: params[:room_id])
     jam = room.jams.build(jam_params)
     if jam.save
       flash[:success] = 'Jam successfully created!'

--- a/app/controllers/rooms_controller.rb
+++ b/app/controllers/rooms_controller.rb
@@ -2,7 +2,7 @@
 
 class RoomsController < ApplicationController
   before_action :set_room, only: %i[show update]
-  # GET /rooms/:room_hash
+  # GET /rooms/:public_id
   def show
     @jams = @room.jams.last(20).to_a
     @current_jam = @jams.shift
@@ -18,6 +18,6 @@ class RoomsController < ApplicationController
   private
 
   def set_room
-    @room = Room.find_by!(room_hash: params[:id])
+    @room = Room.find_by!(public_id: params[:id])
   end
 end

--- a/app/models/room.rb
+++ b/app/models/room.rb
@@ -1,18 +1,18 @@
 # frozen_string_literal: true
 
 class Room < ApplicationRecord
-  validates :room_hash, uniqueness: true
-  after_initialize :generate_room_hash
+  validates :public_id, uniqueness: true
+  after_initialize :generate_public_id
 
   has_many :jams, dependent: :destroy
 
   def to_param
-    room_hash
+    public_id
   end
 
   private
 
-  def generate_room_hash
-    self.room_hash ||= SecureRandom.hex
+  def generate_public_id
+    self.public_id ||= SecureRandom.hex
   end
 end

--- a/app/views/rooms/show.html.erb
+++ b/app/views/rooms/show.html.erb
@@ -1,5 +1,5 @@
 <div>
-  <%= "Home/#{@room.room_hash}"%>
+  <%= "Home/#{@room.public_id}"%>
 </div>
 
 <% if @current_jam %>

--- a/db/migrate/20200321173123_create_rooms.rb
+++ b/db/migrate/20200321173123_create_rooms.rb
@@ -6,7 +6,7 @@ class CreateRooms < ActiveRecord::Migration[6.0]
 
     create_table :rooms do |t|
       t.string :title
-      t.citext :room_hash, null: false, index: { unique: true }
+      t.citext :public_id, null: false, index: { unique: true }
 
       t.timestamps
     end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -12,11 +12,15 @@
 
 ActiveRecord::Schema.define(version: 2020_03_25_182440) do
 
+  # These are extensions that must be enabled in order to support this database
+  enable_extension "citext"
+  enable_extension "plpgsql"
+
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
-    t.integer "record_id", null: false
-    t.integer "blob_id", null: false
+    t.bigint "record_id", null: false
+    t.bigint "blob_id", null: false
     t.datetime "created_at", null: false
     t.index ["blob_id"], name: "index_active_storage_attachments_on_blob_id"
     t.index ["record_type", "record_id", "name", "blob_id"], name: "index_active_storage_attachments_uniqueness", unique: true
@@ -41,7 +45,7 @@ ActiveRecord::Schema.define(version: 2020_03_25_182440) do
 
   create_table "jams", force: :cascade do |t|
     t.string "bpm"
-    t.integer "room_id", null: false
+    t.bigint "room_id", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.index ["room_id"], name: "index_jams_on_room_id"
@@ -49,10 +53,10 @@ ActiveRecord::Schema.define(version: 2020_03_25_182440) do
 
   create_table "rooms", force: :cascade do |t|
     t.string "title"
-    t.string "room_hash", null: false
+    t.citext "public_id", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
-    t.index ["room_hash"], name: "index_rooms_on_room_hash", unique: true
+    t.index ["public_id"], name: "index_rooms_on_public_id", unique: true
   end
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -9,10 +9,10 @@
 #   Character.create(name: 'Luke', movie: movies.first)
 
 # Create an empty room
-Room.create(room_hash: 'empty')
+Room.create(public_id: 'empty')
 
 # Create a room with two attached jams
-room = Room.create(room_hash: 'jams')
+room = Room.create(public_id: 'jams')
 jam = room.jams.build(bpm: '120')
 jam.file.attach(io: File.open('spec/support/assets/test.mp3'), filename: 'test.mp3', content_type: 'audio/mpeg')
 jam.save

--- a/spec/controllers/rooms_controller_spec.rb
+++ b/spec/controllers/rooms_controller_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe RoomsController, type: :controller do
     let(:room) { create(:room) }
 
     it 'renders a room page' do
-      get :show, params: { id: room.room_hash }
+      get :show, params: { id: room.public_id }
       expect(response).to be_successful
     end
 

--- a/spec/models/room_spec.rb
+++ b/spec/models/room_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Room, type: :model do
   end
 
   it 'generates a random hex room hash' do
-    expect(room.room_hash).to match(/[0-9a-f]{32}/)
+    expect(room.public_id).to match(/[0-9a-f]{32}/)
   end
 
   describe '#destroy' do
@@ -28,7 +28,7 @@ RSpec.describe Room, type: :model do
 
   describe '#to_param' do
     it 'returns the room hash' do
-      expect(room.to_param).to eq room.room_hash
+      expect(room.to_param).to eq room.public_id
     end
   end
 end


### PR DESCRIPTION
This PR changes the Room model's `room_hash` attribute to `public_id` (which makes more sense when reading the code).

Since we haven't deployed to a production environment, the original migration that created the room was changed instead of creating a new migration to change the column.