### PR TITLE
Add Sentry for crash reporting

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -33,6 +33,7 @@ gem 'bootsnap', '>= 1.4.2', require: false
 
 group :production do
   gem "aws-sdk-s3", '1.61.1'
+  gem "sentry-raven", '3.0.0'
 end
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -105,6 +105,8 @@ GEM
     factory_bot_rails (5.1.1)
       factory_bot (~> 5.1.0)
       railties (>= 4.2.0)
+    faraday (1.0.0)
+      multipart-post (>= 1.2, < 3)
     ffi (1.12.2)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
@@ -132,6 +134,7 @@ GEM
     mini_portile2 (2.4.0)
     minitest (5.14.0)
     msgpack (1.3.1)
+    multipart-post (2.1.1)
     nio4r (2.5.2)
     nokogiri (1.10.9)
       mini_portile2 (~> 2.4.0)
@@ -217,6 +220,8 @@ GEM
     selenium-webdriver (3.142.7)
       childprocess (>= 0.5, < 4.0)
       rubyzip (>= 1.2.2)
+    sentry-raven (3.0.0)
+      faraday (>= 1.0)
     simplecov (0.18.5)
       docile (~> 1.1)
       simplecov-html (~> 0.11)
@@ -283,6 +288,7 @@ DEPENDENCIES
   rspec-rails (~> 4.0.0.rc1)
   sass-rails (>= 6)
   selenium-webdriver
+  sentry-raven (= 3.0.0)
   simplecov
   simplecov-lcov
   spring


### PR DESCRIPTION
This PR adds the sentry gem for crash reporting. `sentry-raven` is setup to work with Rails apps out of the box, so all we have to do app side is add the gem.

From the Heroku side, I set up `SENTRY_DSN` environment variables. I also had to run `heroku labs:enable runtime-dyno-metadata` for Sentry's release detection to work.