### PR TITLE
Validate that content type of a Jam file is audio

### DIFF
--- a/app/controllers/jams_controller.rb
+++ b/app/controllers/jams_controller.rb
@@ -8,7 +8,7 @@ class JamsController < ApplicationController
     if jam.save
       flash[:success] = 'Jam successfully created!'
     else
-      flash[:danger] = 'A file must be specified.'
+      flash[:danger] = jam.errors.full_messages.join(', ')
     end
     redirect_to room_path(room)
   end

--- a/app/models/jam.rb
+++ b/app/models/jam.rb
@@ -3,5 +3,16 @@
 class Jam < ApplicationRecord
   belongs_to :room
   has_one_attached :file
-  validates :file, presence: true
+  validates :file, presence: { message: "must be attached" }
+  validate :content_type_is_audio
+
+  private
+
+  def content_type_is_audio
+    return unless file.attached?
+
+    unless file.content_type.match(/\Aaudio\/*/)
+      errors.add(:file, "must be an audio file")
+    end
+  end
 end

--- a/app/views/rooms/show.html.erb
+++ b/app/views/rooms/show.html.erb
@@ -63,7 +63,7 @@
           <div class="field">
             <div id="file-upload-field" class="file has-name">
               <label class="file-label">
-                <%= form.file_field :file, class: "file-input" %>
+                <%= form.file_field :file, class: "file-input", accept: "audio/*" %>
                 <span class="file-cta">
                   <span class="file-icon">
                     <i class="fas fa-upload"></i>

--- a/spec/models/jam_spec.rb
+++ b/spec/models/jam_spec.rb
@@ -11,6 +11,14 @@ RSpec.describe Jam, type: :model do
     it 'is not valid without a file' do
       jam.file = nil
       expect(jam).to_not be_valid
+      expect(jam.errors[:file]).to include("must be attached")
+    end
+
+    it 'only allows content types of audio/*' do
+      invalid_file = fixture_file_upload('spec/support/assets/invalid_file.txt')
+      jam = build(:jam, file: invalid_file)
+      expect(jam).to_not be_valid
+      expect(jam.errors[:file]).to include("must be an audio file")
     end
   end
 end

--- a/spec/models/jam_spec.rb
+++ b/spec/models/jam_spec.rb
@@ -1,6 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe Jam, type: :model do
+
   describe 'Validations' do
     let(:jam) { build(:jam) }
 
@@ -15,8 +16,7 @@ RSpec.describe Jam, type: :model do
     end
 
     it 'only allows content types of audio/*' do
-      invalid_file = fixture_file_upload('spec/support/assets/invalid_file.txt')
-      jam = build(:jam, file: invalid_file)
+      jam.file = fixture_file_upload('spec/support/assets/invalid_file.txt')
       expect(jam).to_not be_valid
       expect(jam.errors[:file]).to include("must be an audio file")
     end

--- a/spec/support/assets/invalid_file.txt
+++ b/spec/support/assets/invalid_file.txt
@@ -1,0 +1,1 @@
+This is not a valid audio file.


### PR DESCRIPTION
This PR validates both on the client and server side whether the uploaded has an audio content type.