### PR TITLE
Remove the installing of undercover in before script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ services:
   - postgresql
 before_install:
   - gem install bundler
-  - gem install bundler undercover --no-doc
 before_script:
   - npm install
   - psql -c 'create database jamroulette_test;' -U postgres
@@ -11,4 +10,4 @@ cache: bundler
 script:
   - bundle exec rake
   - git fetch origin master:master
-  - undercover --compare master
+  - bundle exec undercover --compare master


### PR DESCRIPTION
This PR removes the installation of undercover as a `before_install` step in Travis CI. The gem already exists in the Gemfile's test context and because undercover contains a native extension, it takes a long time to finish installing. The `before_install` step also can't take advantage or any Gemfile based caching mechanisms.