### PR TITLE
Ensure Room#random_room returns a room with a jam

### DIFF
--- a/app/models/room.rb
+++ b/app/models/room.rb
@@ -11,7 +11,7 @@ class Room < ApplicationRecord
   end
 
   def self.random_room
-    self.limit(1).order("RANDOM()").take
+    self.joins(:jams).where("jams.id IS NOT NULL").limit(1).order("RANDOM()").take
   end
 
   private

--- a/app/models/room.rb
+++ b/app/models/room.rb
@@ -5,13 +5,10 @@ class Room < ApplicationRecord
   after_initialize :generate_public_id
 
   has_many :jams, dependent: :destroy
+  scope :recommended, -> { joins(:jams).order("RANDOM()") }
 
   def to_param
     public_id
-  end
-
-  def self.random_room
-    self.joins(:jams).where("jams.id IS NOT NULL").limit(1).order("RANDOM()").take
   end
 
   private

--- a/app/views/static/index.html.erb
+++ b/app/views/static/index.html.erb
@@ -8,11 +8,13 @@
         Join a room to start building up a track or start your own.
       </h2>
 
-      <%= link_to(random_room_path, class: "button is-primary is-inverted") do %>
-        <span class="icon">
-          <i class="fas fa-door-open"></i>
-        </span>
-        <span>Join a random room</span>
+      <% if(room = Room.recommended.take) %>
+        <%= link_to(room_path(room), class: "button is-primary is-inverted") do %>
+          <span class="icon">
+            <i class="fas fa-door-open"></i>
+          </span>
+          <span>Join a random room</span>
+        <% end %>
       <% end %>
 
       <%= link_to(rooms_path, method: :post, class: "button is-primary is-inverted") do %>

--- a/spec/models/room_spec.rb
+++ b/spec/models/room_spec.rb
@@ -18,8 +18,8 @@ RSpec.describe Room, type: :model do
   end
 
   describe "Room#random_room" do
-    it 'returns a Jam' do
-      create_list(:room, 2)
+    it 'returns a Room that contains a jam' do
+      create(:jam, room: room)
       expect(Room.random_room).to be_an_instance_of(Room)
     end
   end

--- a/spec/models/room_spec.rb
+++ b/spec/models/room_spec.rb
@@ -27,8 +27,8 @@ RSpec.describe Room, type: :model do
   describe '#destroy' do
     context 'given a jam that belongs to a room' do
       it 'destroys the associated jam' do
-        create(:jam, room: room)
-        expect { room.destroy }.to change(Jam, :count).by(-1)
+        jam = create(:jam)
+        expect { jam.room.destroy! }.to change(Jam, :count).by(-1)
       end
     end
   end

--- a/spec/models/room_spec.rb
+++ b/spec/models/room_spec.rb
@@ -17,10 +17,10 @@ RSpec.describe Room, type: :model do
     expect(room.public_id).to match(/[0-9a-f]{32}/)
   end
 
-  describe "Room#random_room" do
+  describe "Room#recommended" do
     it 'returns a Room that contains a jam' do
       create(:jam, room: room)
-      expect(Room.random_room).to be_an_instance_of(Room)
+      expect(Room.recommended.take).to be_an_instance_of(Room)
     end
   end
 

--- a/spec/requests/rooms_spec.rb
+++ b/spec/requests/rooms_spec.rb
@@ -46,4 +46,17 @@ RSpec.describe 'Room viewing', type: :request do
 
     expect(response.body).to include('This room is brand new! Upload a track to get started!')
   end
+
+  it 'redirects a user to a random room that is not empty' do
+    create(:room, public_id: 'empty-room')
+
+    room = build(:room, public_id: 'room-with-a-jam')
+    create(:jam, room: room)
+    create(:jam)
+
+    get random_room_path
+    follow_redirect!
+
+    expect(response.body).to_not include('This room is brand new! Upload a track to get started!')
+  end
 end

--- a/spec/requests/rooms_spec.rb
+++ b/spec/requests/rooms_spec.rb
@@ -46,17 +46,4 @@ RSpec.describe 'Room viewing', type: :request do
 
     expect(response.body).to include('This room is brand new! Upload a track to get started!')
   end
-
-  it 'redirects a user to a random room that is not empty' do
-    create(:room, public_id: 'empty-room')
-
-    room = build(:room, public_id: 'room-with-a-jam')
-    create(:jam, room: room)
-    create(:jam)
-
-    get random_room_path
-    follow_redirect!
-
-    expect(response.body).to_not include('This room is brand new! Upload a track to get started!')
-  end
 end

--- a/spec/system/home_page_spec.rb
+++ b/spec/system/home_page_spec.rb
@@ -39,6 +39,8 @@ RSpec.describe 'visiting the home page', type: :system do
       room = build(:room, public_id: "random-room")
       create(:jam, room: room)
 
+      visit home_path
+
       click_link('Join a random room')
 
       expect(page).to have_content('random-room')

--- a/spec/system/home_page_spec.rb
+++ b/spec/system/home_page_spec.rb
@@ -35,8 +35,9 @@ RSpec.describe 'visiting the home page', type: :system do
       click_on 'Go'
     end
 
-    it 'allows a user to join a random room' do
-      room = create(:room, public_id: "random-room")
+    it 'allows a user to join a random room that contains a jam' do
+      room = build(:room, public_id: "random-room")
+      create(:jam, room: room)
 
       click_link('Join a random room')
 


### PR DESCRIPTION
https://github.com/tomekr/jamroulette/pull/16 would redirect users to empty rooms. This PR redirects users only to rooms that have a Jam associated with it.