### PR TITLE
Redirect user to referrer if it exists

### DIFF
--- a/app/controllers/static_controller.rb
+++ b/app/controllers/static_controller.rb
@@ -12,7 +12,7 @@ class StaticController < ApplicationController
     if InviteCode.find_by_code(params[:beta_code])
       session[:is_beta_user] = true
       flash[:success] = 'Welcome! Thanks for helping beta test Jam Roulette!'
-      redirect_to home_path
+      redirect_back fallback_location: home_path
     else
       session[:is_beta_user] = false
       flash[:danger] = 'Invalid invite code.'

--- a/spec/controllers/static_controller_spec.rb
+++ b/spec/controllers/static_controller_spec.rb
@@ -3,15 +3,30 @@
 require 'rails_helper'
 
 RSpec.describe StaticController, type: :controller do
-  # TODO: Remove when beta invite requirements are removed
-  before(:each) do
-    session[:is_beta_user] = true
-  end
-
   describe 'GET #index' do
+    # TODO: Remove when beta invite requirements are removed
+    before(:each) do
+      session[:is_beta_user] = true
+    end
+
     it 'returns http success' do
       get :index
       expect(response).to have_http_status(:success)
+    end
+  end
+
+  # TODO: Remove when beta invite requirements are removed
+  describe 'POST #validate_beta_user' do
+    context 'with valid invite code' do
+      it 'redirects to referer if it exists' do
+        InviteCode.create(code: 'valid-code')
+        room = create(:room)
+
+        request.env['HTTP_REFERER'] = room_path(room)
+        post :validate_beta_user, params: { beta_code: 'valid-code' }
+
+        expect(response).to redirect_to room_path(room)
+      end
     end
   end
 end


### PR DESCRIPTION
When sharing a room link, a user who has not entered a valid invite code will visit the link and be redirected to the invite code entry page. After entering the code, they are redirected to the home page, losing the routing to the room path they wanted to go to, which results in a confusing UX experience.

This PR redirects the user back to the page they were from (via the Referrer header if it exists)