### PR TITLE
Use session to redirect users after beta invite code entry

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -6,6 +6,9 @@ class ApplicationController < ActionController::Base
   private
 
   def ensure_beta_user
-    redirect_to root_path unless session[:is_beta_user]
+    unless session[:is_beta_user]
+      session[:redirect_to] = request.url
+      redirect_to root_path
+    end
   end
 end

--- a/app/controllers/static_controller.rb
+++ b/app/controllers/static_controller.rb
@@ -12,7 +12,13 @@ class StaticController < ApplicationController
     if InviteCode.find_by_code(params[:beta_code])
       session[:is_beta_user] = true
       flash[:success] = 'Welcome! Thanks for helping beta test Jam Roulette!'
-      redirect_back fallback_location: home_path
+
+      if session[:redirect_to]
+        redirect_url = session.delete(:redirect_to)
+        redirect_to redirect_url
+      else
+        redirect_to home_path
+      end
     else
       session[:is_beta_user] = false
       flash[:danger] = 'Invalid invite code.'

--- a/spec/controllers/static_controller_spec.rb
+++ b/spec/controllers/static_controller_spec.rb
@@ -14,19 +14,4 @@ RSpec.describe StaticController, type: :controller do
       expect(response).to have_http_status(:success)
     end
   end
-
-  # TODO: Remove when beta invite requirements are removed
-  describe 'POST #validate_beta_user' do
-    context 'with valid invite code' do
-      it 'redirects to referer if it exists' do
-        InviteCode.create(code: 'valid-code')
-        room = create(:room)
-
-        request.env['HTTP_REFERER'] = room_path(room)
-        post :validate_beta_user, params: { beta_code: 'valid-code' }
-
-        expect(response).to redirect_to room_path(room)
-      end
-    end
-  end
 end

--- a/spec/requests/home_page_request_spec.rb
+++ b/spec/requests/home_page_request_spec.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Home page viewing', type: :request do
+  # TODO: Remove when beta invite requirements are removed
+  it 'redirects to room after code validation if user first visited room' do
+    InviteCode.create(code: 'correct-code')
+    room = create(:room)
+
+    get room_path(room)
+    follow_redirect!
+
+    post '/validate_beta_user', params: { beta_code: 'correct-code' }
+    expect(response).to redirect_to(room_path(room))
+  end
+end


### PR DESCRIPTION
Fixes issue from #20 where referrer header was not available the request path was `/rooms/:public_id` -> `/` -> `/validate_beta_user`.