### PR TITLE
Display an Activity Feed for logged in Users using an ActivityPresenter

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -50,6 +50,7 @@ group :development do
   # Spring speeds up development by keeping your application running in the background. Read more: https://github.com/rails/spring
   gem 'spring'
   gem 'spring-watcher-listen', '~> 2.0.0'
+  gem 'pry-rails'
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -94,6 +94,7 @@ GEM
       regexp_parser (~> 1.5)
       xpath (~> 3.2)
     childprocess (3.0.0)
+    coderay (1.1.2)
     concurrent-ruby (1.1.5)
     connection_pool (2.2.2)
     crass (1.0.6)
@@ -149,6 +150,11 @@ GEM
     parser (2.7.0.5)
       ast (~> 2.4.0)
     pg (1.2.3)
+    pry (0.12.2)
+      coderay (~> 1.1.0)
+      method_source (~> 0.9.0)
+    pry-rails (0.3.9)
+      pry (>= 0.10.4)
     public_suffix (4.0.3)
     puma (4.3.3)
       nio4r (~> 2.0)
@@ -296,6 +302,7 @@ DEPENDENCIES
   jbuilder (~> 2.7)
   listen (>= 3.0.5, < 3.2)
   pg (~> 1.2)
+  pry-rails
   puma (~> 4.3)
   rails (~> 6.0.2, >= 6.0.2.1)
   react-rails

--- a/app/controllers/jams_controller.rb
+++ b/app/controllers/jams_controller.rb
@@ -6,11 +6,10 @@ class JamsController < ApplicationController
     room = Room.find_by!(public_id: params[:room_id])
     jam = room.jams.build(jam_params)
 
-    if user_signed_in?
-      jam.user = current_user
-    end
+    jam.user = current_user
 
     if jam.save
+      jam.activities.create!(user: current_user)
       flash[:success] = 'Jam successfully created!'
     else
       flash[:danger] = jam.errors.full_messages.join(', ')

--- a/app/controllers/rooms_controller.rb
+++ b/app/controllers/rooms_controller.rb
@@ -14,6 +14,7 @@ class RoomsController < ApplicationController
   # POST /rooms
   def create
     room = Room.create!
+    room.activities.create!(user: current_user)
     redirect_to room_path(room)
   end
 

--- a/app/controllers/static_controller.rb
+++ b/app/controllers/static_controller.rb
@@ -4,7 +4,9 @@ class StaticController < ApplicationController
   skip_before_action :ensure_beta_user, only: %i[beta validate_beta_user]
   skip_before_action :authenticate_user!
 
-  def index; end
+  def index
+    @activities = current_user.activities if current_user
+  end
 
   def beta
     redirect_to home_path if session[:is_beta_user]

--- a/app/controllers/static_controller.rb
+++ b/app/controllers/static_controller.rb
@@ -5,7 +5,7 @@ class StaticController < ApplicationController
   skip_before_action :authenticate_user!
 
   def index
-    @activities = current_user.activities if current_user
+    @activities = current_user&.activities
   end
 
   def beta

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -1,0 +1,4 @@
+class Activity < ApplicationRecord
+  belongs_to :user
+  belongs_to :subject, polymorphic: true
+end

--- a/app/models/jam.rb
+++ b/app/models/jam.rb
@@ -7,7 +7,7 @@ class Jam < ApplicationRecord
   validates :file, presence: { message: "must be attached" }
   validate :content_type_is_audio
 
-  has_many :activities, as: :subject
+  has_many :activities, as: :subject, dependent: :destroy
 
   private
 

--- a/app/models/jam.rb
+++ b/app/models/jam.rb
@@ -7,6 +7,8 @@ class Jam < ApplicationRecord
   validates :file, presence: { message: "must be attached" }
   validate :content_type_is_audio
 
+  has_many :activities, as: :subject
+
   private
 
   def content_type_is_audio

--- a/app/models/room.rb
+++ b/app/models/room.rb
@@ -5,6 +5,8 @@ class Room < ApplicationRecord
   after_initialize :generate_public_id
 
   has_many :jams, dependent: :destroy
+  has_many :activities, as: :subject
+
   scope :recommended, -> { joins(:jams).order("RANDOM()") }
 
   def to_param

--- a/app/models/room.rb
+++ b/app/models/room.rb
@@ -5,7 +5,7 @@ class Room < ApplicationRecord
   after_initialize :generate_public_id
 
   has_many :jams, dependent: :destroy
-  has_many :activities, as: :subject
+  has_many :activities, as: :subject, dependent: :destroy
 
   scope :recommended, -> { joins(:jams).order("RANDOM()") }
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,4 +5,5 @@ class User < ApplicationRecord
          :recoverable, :rememberable, :validatable,
          :confirmable, :trackable
   has_many :jams, dependent: :restrict_with_exception
+  has_many :activities, dependent: :destroy
 end

--- a/app/presenters/activity_presenter.rb
+++ b/app/presenters/activity_presenter.rb
@@ -1,23 +1,23 @@
 class ActivityPresenter < SimpleDelegator
+  include ActionView::Helpers::UrlHelper
   include ActionView::Helpers::SanitizeHelper
 
-  def self.activities(*activities)
-    activities.flatten.map { |activity| ActivityPresenter.new(activity) }
+  def self.activities(owner)
+    owner.activities.map { |activity| new(activity) }
   end
 
   def initialize(activity)
-    @activity = activity
     super
   end
 
   def activity_feed_line
-    case @activity.subject_type
+    case subject_type
     when "Jam"
-      jam = @activity.subject
+      jam = subject
       filename = sanitize(jam.file.filename.to_s)
       "<span class='jam-activity'>You uploaded #{filename} to #{room_link_for(jam.room)}</span>".html_safe
     when "Room"
-      room = @activity.subject
+      room = subject
       "<span class='room-activity'>You created #{room_link_for(room)}</span>".html_safe
     end
   end
@@ -25,6 +25,6 @@ class ActivityPresenter < SimpleDelegator
   private
 
   def room_link_for(room)
-    "<a href='/rooms/#{room.public_id}'>#{room.public_id}"
+    link_to room.public_id, "/rooms/#{room.public_id}"
   end
 end

--- a/app/presenters/activity_presenter.rb
+++ b/app/presenters/activity_presenter.rb
@@ -1,30 +1,44 @@
 class ActivityPresenter < SimpleDelegator
-  include ActionView::Helpers::UrlHelper
   include ActionView::Helpers::SanitizeHelper
 
-  def self.activities(owner)
-    owner.activities.map { |activity| new(activity) }
+  def self.activities(owner, view)
+    owner.activities.map { |activity| new(activity, view) }
   end
 
-  def initialize(activity)
-    super
+  def initialize(activity, view)
+    super(activity)
+    @view = view
   end
 
-  def activity_feed_line
+  # XXX Ensure all user controlled attributes are sanitized before embedding them into HTML
+  def message
     case subject_type
     when "Jam"
-      jam = subject
-      filename = sanitize(jam.file.filename.to_s)
-      "<span class='jam-activity'>You uploaded #{filename} to #{room_link_for(jam.room)}</span>".html_safe
+      "You uploaded #{jam_icon} #{sanitized_filename} to #{room_icon} #{room_link_for(subject.room)}".html_safe
     when "Room"
-      room = subject
-      "<span class='room-activity'>You created #{room_link_for(room)}</span>".html_safe
+      "You created #{room_icon} #{room_link_for(subject)}".html_safe
     end
+  end
+
+  def type
+    subject_type.downcase
   end
 
   private
 
+  def sanitized_filename
+    sanitize(subject&.file&.filename.to_s)
+  end
+
   def room_link_for(room)
-    link_to room.public_id, "/rooms/#{room.public_id}"
+    @view.link_to room.public_id, @view.room_path(room)
+  end
+
+  def room_icon
+    '<i class="fas fa-door-open"></i>'
+  end
+
+  def jam_icon
+    '<i class="fas fa-music"></i>'
   end
 end

--- a/app/presenters/activity_presenter.rb
+++ b/app/presenters/activity_presenter.rb
@@ -1,0 +1,30 @@
+class ActivityPresenter < SimpleDelegator
+  include ActionView::Helpers::SanitizeHelper
+
+  def self.activities(*activities)
+    activities.flatten.map { |activity| ActivityPresenter.new(activity) }
+  end
+
+  def initialize(activity)
+    @activity = activity
+    super
+  end
+
+  def activity_feed_line
+    case @activity.subject_type
+    when "Jam"
+      jam = @activity.subject
+      filename = sanitize(jam.file.filename.to_s)
+      "<span class='jam-activity'>You uploaded #{filename} to #{room_link_for(jam.room)}</span>".html_safe
+    when "Room"
+      room = @activity.subject
+      "<span class='jam-activity'>You created #{room_link_for(room)}</span>".html_safe
+    end
+  end
+
+  private
+
+  def room_link_for(room)
+    "<a href='/rooms/#{room.public_id}'>#{room.public_id}"
+  end
+end

--- a/app/presenters/activity_presenter.rb
+++ b/app/presenters/activity_presenter.rb
@@ -18,7 +18,7 @@ class ActivityPresenter < SimpleDelegator
       "<span class='jam-activity'>You uploaded #{filename} to #{room_link_for(jam.room)}</span>".html_safe
     when "Room"
       room = @activity.subject
-      "<span class='jam-activity'>You created #{room_link_for(room)}</span>".html_safe
+      "<span class='room-activity'>You created #{room_link_for(room)}</span>".html_safe
     end
   end
 

--- a/app/views/shared/_activity_feed.html.erb
+++ b/app/views/shared/_activity_feed.html.erb
@@ -1,8 +1,8 @@
 <table class="table">
   <tbody>
-    <% activities.each do |activity| %>
+    <% ActivityPresenter.activities(activities).each do |presenter| %>
       <tr>
-        <td><%= "You uploaded #{activity.subject.file.filename} to #{activity.subject.room.public_id}" %></td>
+        <td><%= presenter.activity_feed_line %></td>
       </tr>
     <% end %>
   </tbody>

--- a/app/views/shared/_activity_feed.html.erb
+++ b/app/views/shared/_activity_feed.html.erb
@@ -1,8 +1,10 @@
+<h1 class="title">Activity Feed</h1>
+
 <table class="table">
   <tbody>
-    <% ActivityPresenter.activities(activities).each do |presenter| %>
+    <% ActivityPresenter.activities(owner).each do |activity| %>
       <tr>
-        <td><%= presenter.activity_feed_line %></td>
+        <td><%= activity.activity_feed_line %></td>
       </tr>
     <% end %>
   </tbody>

--- a/app/views/shared/_activity_feed.html.erb
+++ b/app/views/shared/_activity_feed.html.erb
@@ -1,0 +1,9 @@
+<table class="table">
+  <tbody>
+    <% activities.each do |activity| %>
+      <tr>
+        <td><%= "You uploaded #{activity.subject.file.filename} to #{activity.subject.room.public_id}" %></td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>

--- a/app/views/shared/_activity_feed.html.erb
+++ b/app/views/shared/_activity_feed.html.erb
@@ -2,9 +2,11 @@
 
 <table class="table">
   <tbody>
-    <% ActivityPresenter.activities(owner).each do |activity| %>
+    <% ActivityPresenter.activities(owner, self).each do |activity| %>
       <tr>
-        <td><%= activity.activity_feed_line %></td>
+        <td>
+          <span class='<%= activity.type %>-activity'><%= activity.message %></span>
+        </td>
       </tr>
     <% end %>
   </tbody>

--- a/app/views/static/index.html.erb
+++ b/app/views/static/index.html.erb
@@ -26,11 +26,9 @@
         <% end %>
       </section>
 
-      <% if user_signed_in? && !@activities.empty? %>
+      <% if @current_user&.activities&.any? %>
         <section class="section">
-          <h1 class="title">Activity Feed</h1>
-
-          <%= render "shared/activity_feed", activities: @activities %>
+          <%= render "shared/activity_feed", owner: @current_user %>
         </section>
       <% end %>
     </div>

--- a/app/views/static/index.html.erb
+++ b/app/views/static/index.html.erb
@@ -1,27 +1,37 @@
 <section class="hero is-primary is-fullheight is-bold">
   <div class="hero-body">
     <div class="container">
-      <h1 class="title">
-        Jam Roulette. Add your part.
-      </h1>
-      <h2 class="subtitle">
-        Join a room to start building up a track or start your own.
-      </h2>
+      <section class="section">
+        <h1 class="title">
+          Jam Roulette. Add your part.
+        </h1>
+        <h2 class="subtitle">
+          Join a room to start building up a track or start your own.
+        </h2>
 
-      <% if(room = Room.recommended.take) %>
-        <%= link_to(room_path(room), class: "button is-primary is-inverted") do %>
-          <span class="icon">
-            <i class="fas fa-door-open"></i>
-          </span>
-          <span>Join a random room</span>
+        <% if(room = Room.recommended.take) %>
+          <%= link_to(room_path(room), class: "button is-primary is-inverted") do %>
+            <span class="icon">
+              <i class="fas fa-door-open"></i>
+            </span>
+            <span>Join a random room</span>
+          <% end %>
         <% end %>
-      <% end %>
 
-      <%= link_to(rooms_path, method: :post, class: "button is-primary is-inverted") do %>
-        <span class="icon">
-          <i class="fas fa-plus-circle"></i>
-        </span>
-        <span>Create a new room</span>
+        <%= link_to(rooms_path, method: :post, class: "button is-primary is-inverted") do %>
+          <span class="icon">
+            <i class="fas fa-plus-circle"></i>
+          </span>
+          <span>Create a new room</span>
+        <% end %>
+      </section>
+
+      <% if user_signed_in? && !@activities.empty? %>
+        <section class="section">
+          <h1 class="title">Activity Feed</h1>
+
+          <%= render "shared/activity_feed", activities: @activities %>
+        </section>
       <% end %>
     </div>
   </div>

--- a/db/migrate/20200329191513_create_activities.rb
+++ b/db/migrate/20200329191513_create_activities.rb
@@ -1,0 +1,10 @@
+class CreateActivities < ActiveRecord::Migration[6.0]
+  def change
+    create_table :activities do |t|
+      t.references :subject, polymorphic: true, null: false
+      t.references :user, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_03_28_203556) do
+ActiveRecord::Schema.define(version: 2020_03_29_191513) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -35,6 +35,16 @@ ActiveRecord::Schema.define(version: 2020_03_28_203556) do
     t.string "checksum", null: false
     t.datetime "created_at", null: false
     t.index ["key"], name: "index_active_storage_blobs_on_key", unique: true
+  end
+
+  create_table "activities", force: :cascade do |t|
+    t.string "subject_type", null: false
+    t.bigint "subject_id", null: false
+    t.bigint "user_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["subject_type", "subject_id"], name: "index_activities_on_subject_type_and_subject_id"
+    t.index ["user_id"], name: "index_activities_on_user_id"
   end
 
   create_table "invite_codes", force: :cascade do |t|
@@ -85,6 +95,7 @@ ActiveRecord::Schema.define(version: 2020_03_28_203556) do
   end
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "activities", "users"
   add_foreign_key "jams", "rooms"
   add_foreign_key "jams", "users"
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -8,23 +8,7 @@
 #   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
 #   Character.create(name: 'Luke', movie: movies.first)
 
-# Create an empty room
-Room.create(public_id: 'empty')
-
-# Create a room with two attached jams
-room = Room.create(public_id: 'jams')
-jam = room.jams.build(bpm: '120')
-jam.file.attach(io: File.open('spec/support/assets/test.mp3'), filename: 'test.mp3', content_type: 'audio/mpeg')
-jam.save
-
-other_jam = room.jams.build(bpm: '120')
-other_jam.file.attach(io: File.open('spec/support/assets/test.mp3'), filename: 'test.mp3', content_type: 'audio/mpeg')
-other_jam.save
-
-# TODO Remove when no longer in beta
-InviteCode.create(code: 'Mellon')
-
-User.create(
+bob = User.create(
   display_name: 'bobby',
   email: 'bob@example.com',
   password: 'password',
@@ -32,10 +16,31 @@ User.create(
   confirmed_at: Time.now
 )
 
-User.create(
+alice = User.create(
   display_name: 'alice',
   email: 'alice@example.com',
   password: 'password',
   password_confirmation: 'password',
   confirmed_at: Time.now
 )
+
+# Create an empty room
+Room.create(public_id: 'empty')
+
+# Create a room with two attached jams
+room = Room.create(public_id: 'jams')
+jam = room.jams.build(bpm: '120', user: bob)
+jam.file.attach(io: File.open('spec/support/assets/test.mp3'), filename: 'test.mp3', content_type: 'audio/mpeg')
+jam.save
+
+jam.activities.create(user: jam.user)
+
+other_jam = room.jams.build(bpm: '120', user: alice)
+other_jam.file.attach(io: File.open('spec/support/assets/test.mp3'), filename: 'test.mp3', content_type: 'audio/mpeg')
+other_jam.save
+
+other_jam.activities.create(user: other_jam.user)
+
+# TODO Remove when no longer in beta
+InviteCode.create(code: 'Mellon')
+

--- a/spec/factories/activities.rb
+++ b/spec/factories/activities.rb
@@ -1,0 +1,13 @@
+FactoryBot.define do
+  factory :activity do
+    user
+
+    trait :jam do
+      association :subject, factory: :jam
+    end
+
+    trait :room do
+      association :subject, factory: :room
+    end
+  end
+end

--- a/spec/presenters/activity_presenter_spec.rb
+++ b/spec/presenters/activity_presenter_spec.rb
@@ -18,7 +18,7 @@ describe ActivityPresenter do
     it "displays filename and room link" do
       allow(jam_activity).to receive(:subject_type).and_return("Jam")
       expect(presenter.activity_feed_line).to eq(
-        "<span class='jam-activity'>You uploaded test.mp3 to <a href='/rooms/activity-presenter-room'>activity-presenter-room</span>"
+        "<span class='jam-activity'>You uploaded test.mp3 to <a href=\"/rooms/activity-presenter-room\">activity-presenter-room</a></span>"
       )
     end
   end
@@ -29,7 +29,7 @@ describe ActivityPresenter do
     it "displays the room link" do
       allow(room_activity).to receive(:subject_type).and_return("Room")
       expect(presenter.activity_feed_line).to eq(
-        "<span class='room-activity'>You created <a href='/rooms/activity-presenter-room'>activity-presenter-room</span>"
+        "<span class='room-activity'>You created <a href=\"/rooms/activity-presenter-room\">activity-presenter-room</a></span>"
       )
     end
   end

--- a/spec/presenters/activity_presenter_spec.rb
+++ b/spec/presenters/activity_presenter_spec.rb
@@ -26,7 +26,7 @@ describe ActivityPresenter do
   context 'presenting a room' do
     let(:activity) { room_activity }
 
-    it "displays the room public_id" do
+    it "displays the room link" do
       allow(room_activity).to receive(:subject_type).and_return("Room")
       expect(presenter.activity_feed_line).to eq(
         "<span class='room-activity'>You created <a href='/rooms/activity-presenter-room'>activity-presenter-room</span>"

--- a/spec/presenters/activity_presenter_spec.rb
+++ b/spec/presenters/activity_presenter_spec.rb
@@ -29,7 +29,7 @@ describe ActivityPresenter do
     it "displays the room public_id" do
       allow(room_activity).to receive(:subject_type).and_return("Room")
       expect(presenter.activity_feed_line).to eq(
-        "<span class='jam-activity'>You created <a href='/rooms/activity-presenter-room'>activity-presenter-room</span>"
+        "<span class='room-activity'>You created <a href='/rooms/activity-presenter-room'>activity-presenter-room</span>"
       )
     end
   end

--- a/spec/presenters/activity_presenter_spec.rb
+++ b/spec/presenters/activity_presenter_spec.rb
@@ -1,22 +1,15 @@
 require "rails_helper"
 
 describe ActivityPresenter do
-  # instance_double won't work for ActiveStorage::Attached::One since filename
-  # is not an instance_method on that class.
-  let(:file) { double(ActiveStorage::Attached::One, filename: 'test.mp3') }
-  let(:room) { instance_double(Room, public_id: 'activity-presenter-room') }
-  let(:jam) { instance_double(Jam, file: file, room: room) }
-
-  let(:room_activity) { instance_double(Activity, subject: room) }
-  let(:jam_activity) { instance_double(Activity, subject: jam) }
-
+  let(:room) { build(:room, public_id: 'activity-presenter-room') }
   let(:presenter) { ActivityPresenter.new(activity) }
 
   context 'presenting a jam' do
-    let(:activity) { jam_activity }
+    let(:jam) { build(:jam, room: room) }
+    let(:activity) { create(:activity, :room, subject: jam) }
 
     it "displays filename and room link" do
-      allow(jam_activity).to receive(:subject_type).and_return("Jam")
+      allow(activity).to receive(:subject_type).and_return("Jam")
       expect(presenter.activity_feed_line).to eq(
         "<span class='jam-activity'>You uploaded test.mp3 to <a href=\"/rooms/activity-presenter-room\">activity-presenter-room</a></span>"
       )
@@ -24,10 +17,10 @@ describe ActivityPresenter do
   end
 
   context 'presenting a room' do
-    let(:activity) { room_activity }
+    let(:activity) { create(:activity, :room, subject: room) }
 
     it "displays the room link" do
-      allow(room_activity).to receive(:subject_type).and_return("Room")
+      allow(activity).to receive(:subject_type).and_return("Room")
       expect(presenter.activity_feed_line).to eq(
         "<span class='room-activity'>You created <a href=\"/rooms/activity-presenter-room\">activity-presenter-room</a></span>"
       )

--- a/spec/presenters/activity_presenter_spec.rb
+++ b/spec/presenters/activity_presenter_spec.rb
@@ -1,17 +1,22 @@
 require "rails_helper"
 
 describe ActivityPresenter do
+  include ActionView::TestCase::Behavior
+
   let(:room) { build(:room, public_id: 'activity-presenter-room') }
-  let(:presenter) { ActivityPresenter.new(activity) }
+  let(:presenter) { ActivityPresenter.new(activity, view) }
 
   context 'presenting a jam' do
     let(:jam) { build(:jam, room: room) }
     let(:activity) { create(:activity, :room, subject: jam) }
 
-    it "displays filename and room link" do
-      allow(activity).to receive(:subject_type).and_return("Jam")
-      expect(presenter.activity_feed_line).to eq(
-        "<span class='jam-activity'>You uploaded test.mp3 to <a href=\"/rooms/activity-presenter-room\">activity-presenter-room</a></span>"
+    it 'returns correct type' do
+      expect(presenter.type).to eq('jam')
+    end
+
+    it 'returns a message' do
+      expect(presenter.message).to eq(
+        "You uploaded <i class=\"fas fa-music\"></i> test.mp3 to <i class=\"fas fa-door-open\"></i> <a href=\"/rooms/activity-presenter-room\">activity-presenter-room</a>"
       )
     end
   end
@@ -19,10 +24,13 @@ describe ActivityPresenter do
   context 'presenting a room' do
     let(:activity) { create(:activity, :room, subject: room) }
 
-    it "displays the room link" do
-      allow(activity).to receive(:subject_type).and_return("Room")
-      expect(presenter.activity_feed_line).to eq(
-        "<span class='room-activity'>You created <a href=\"/rooms/activity-presenter-room\">activity-presenter-room</a></span>"
+    it 'returns correct type' do
+      expect(presenter.type).to eq('room')
+    end
+
+    it 'returns a message' do
+      expect(presenter.message).to eq(
+        "You created <i class=\"fas fa-door-open\"></i> <a href=\"/rooms/activity-presenter-room\">activity-presenter-room</a>"
       )
     end
   end

--- a/spec/presenters/activity_presenter_spec.rb
+++ b/spec/presenters/activity_presenter_spec.rb
@@ -1,0 +1,36 @@
+require "rails_helper"
+
+describe ActivityPresenter do
+  # instance_double won't work for ActiveStorage::Attached::One since filename
+  # is not an instance_method on that class.
+  let(:file) { double(ActiveStorage::Attached::One, filename: 'test.mp3') }
+  let(:room) { instance_double(Room, public_id: 'activity-presenter-room') }
+  let(:jam) { instance_double(Jam, file: file, room: room) }
+
+  let(:room_activity) { instance_double(Activity, subject: room) }
+  let(:jam_activity) { instance_double(Activity, subject: jam) }
+
+  let(:presenter) { ActivityPresenter.new(activity) }
+
+  context 'presenting a jam' do
+    let(:activity) { jam_activity }
+
+    it "displays filename and room link" do
+      allow(jam_activity).to receive(:subject_type).and_return("Jam")
+      expect(presenter.activity_feed_line).to eq(
+        "<span class='jam-activity'>You uploaded test.mp3 to <a href='/rooms/activity-presenter-room'>activity-presenter-room</span>"
+      )
+    end
+  end
+
+  context 'presenting a room' do
+    let(:activity) { room_activity }
+
+    it "displays the room public_id" do
+      allow(room_activity).to receive(:subject_type).and_return("Room")
+      expect(presenter.activity_feed_line).to eq(
+        "<span class='jam-activity'>You created <a href='/rooms/activity-presenter-room'>activity-presenter-room</span>"
+      )
+    end
+  end
+end

--- a/spec/requests/controllers/jams_controller_spec.rb
+++ b/spec/requests/controllers/jams_controller_spec.rb
@@ -2,24 +2,26 @@ require 'rails_helper'
 
 RSpec.describe JamsController, type: :request do
   # TODO: Remove when beta invite requirements are removed
-  before(:each) do
+  before do
     InviteCode.create(code: 'correct-code')
     post '/validate_beta_user', params: { beta_code: 'correct-code' }
   end
 
-  let(:user) { create(:user, display_name: "Alice") }
-  before(:each) { sign_in user }
-
   let(:room) { create(:room) }
 
   describe 'POST #create' do
+    it_behaves_like 'Auth Required'
+    let(:user) { create(:user) }
+    before { sign_in(user) }
+
     let(:file) { fixture_file_upload('spec/support/assets/test.mp3') }
     let(:jam_params) { { bpm: '100', file: file } }
-    let(:upload_jam) { post room_jams_path(room), params: { jam: jam_params } }
     let(:uploaded_jam) { room.reload.jams.first }
 
+    let(:action) { post room_jams_path(room), params: { jam: jam_params } }
+
     it 'uploads a jam' do
-      upload_jam
+      action
 
       expect(uploaded_jam).to_not be_nil
       expect(uploaded_jam.file.filename).to eq file.original_filename
@@ -27,7 +29,7 @@ RSpec.describe JamsController, type: :request do
     end
 
     it 'lists the uploaded jam' do
-      upload_jam
+      action
       follow_redirect!
 
       expect(response.body).to include(file.original_filename)
@@ -37,12 +39,12 @@ RSpec.describe JamsController, type: :request do
 
     it 'creates an activity' do
       expect do
-        upload_jam
+        action
       end.to change(Activity, :count).from(0).to(1)
     end
 
     it 'associates the activity with the current user' do
-      upload_jam
+      action
       expect(uploaded_jam.activities.first.user).to eq user
     end
 
@@ -50,7 +52,7 @@ RSpec.describe JamsController, type: :request do
       let(:file) { fixture_file_upload('spec/support/assets/invalid_file.txt') }
 
       it "redirects to the home page" do
-        upload_jam
+        action
         expect(request).to redirect_to(room_path(room))
       end
     end

--- a/spec/requests/controllers/jams_controller_spec.rb
+++ b/spec/requests/controllers/jams_controller_spec.rb
@@ -35,6 +35,17 @@ RSpec.describe JamsController, type: :request do
       expect(response.body).to include('Jam successfully created!')
     end
 
+    it 'creates an activity' do
+      expect do
+        upload_jam
+      end.to change(Activity, :count).from(0).to(1)
+    end
+
+    it 'associates the activity with the current user' do
+      upload_jam
+      expect(uploaded_jam.activities.first.user).to eq user
+    end
+
     context "with an invalid file" do
       let(:file) { fixture_file_upload('spec/support/assets/invalid_file.txt') }
 

--- a/spec/requests/controllers/rooms_controller_spec.rb
+++ b/spec/requests/controllers/rooms_controller_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe RoomsController, type: :request do
   # TODO: Remove when beta invite requirements are removed
-  before(:each) do
+  before do
     InviteCode.create(code: 'correct-code')
     post '/validate_beta_user', params: { beta_code: 'correct-code' }
   end
@@ -22,24 +22,26 @@ RSpec.describe RoomsController, type: :request do
     end
   end
 
-  context "user is authenticated" do
+  describe 'POST #create' do
+    it_behaves_like "Auth Required"
+    let(:action) { post rooms_path }
+
     let(:user) { create(:user) }
-    before(:each) { sign_in user }
+    before { sign_in(user) }
 
-    describe 'POST #create' do
-      it 'creates a room' do
-        expect { post rooms_path }.to change(Room, :count).by(1)
-      end
 
-      it 'creates an activity' do
-        expect { post rooms_path }.to change(Activity, :count).by(1)
-      end
+    it 'creates a room' do
+      expect { action }.to change(Room, :count).by(1)
+    end
 
-      it 'associates the activity with the current user' do
-        post rooms_path
-        room = Room.last
-        expect(room.activities.take.user).to eq user
-      end
+    it 'creates an activity' do
+      expect { action }.to change(Activity, :count).by(1)
+    end
+
+    it 'associates the activity with the current user' do
+      action
+      room = Room.last
+      expect(room.activities.take.user).to eq user
     end
   end
 end

--- a/spec/requests/controllers/rooms_controller_spec.rb
+++ b/spec/requests/controllers/rooms_controller_spec.rb
@@ -27,15 +27,17 @@ RSpec.describe RoomsController, type: :request do
     before(:each) { sign_in user }
 
     describe 'POST #create' do
+      it 'creates a room' do
+        expect { post rooms_path }.to change(Room, :count).by(1)
+      end
+
       it 'creates an activity' do
-        expect do
-          post rooms_path
-        end.to change(Activity, :count).from(0).to(1)
+        expect { post rooms_path }.to change(Activity, :count).by(1)
       end
 
       it 'associates the activity with the current user' do
         post rooms_path
-        room = Room.take
+        room = Room.last
         expect(room.activities.take.user).to eq user
       end
     end

--- a/spec/support/shared_examples/auth_required_shared_example.rb
+++ b/spec/support/shared_examples/auth_required_shared_example.rb
@@ -1,0 +1,6 @@
+RSpec.shared_examples "Auth Required" do
+  it "requires authentication" do
+    sign_out :user
+    expect(action).to redirect_to(new_user_session_path)
+  end
+end

--- a/spec/system/home_page_spec.rb
+++ b/spec/system/home_page_spec.rb
@@ -47,9 +47,8 @@ RSpec.describe 'visiting the home page', type: :system do
     end
 
     context "user is authenticated" do
-      before(:each) do
-        sign_in create(:user)
-      end
+      let(:user) { create(:user) }
+      before(:each) { sign_in user }
 
       it 'allows a user to create a new room' do
         visit home_path
@@ -63,6 +62,19 @@ RSpec.describe 'visiting the home page', type: :system do
         click_on('Sign Out')
 
         expect(page).to have_content('Signed out successfully')
+      end
+
+      context 'activity feed' do
+        it 'allows user to view a jam they uploaded' do
+          activity = create(:activity, :jam, user: user)
+          jam = activity.subject
+          room = jam.room
+
+          visit home_path
+
+          expect(page).to have_content("Activity Feed")
+          expect(page).to have_content("You uploaded #{jam.file.filename} to #{room.public_id}")
+        end
       end
     end
   end


### PR DESCRIPTION
This PR adds an activity feed to the home page if the user is logged in and has Activities associated with their account. 

![activity-feed](https://user-images.githubusercontent.com/723637/77863821-d058fc00-71ea-11ea-87f2-dbf84fc21b9a.png)

Points of interest:
* https://github.com/tomekr/jamroulette/commit/1a1b4eade84719ab0137eacb9952285d63a62a62 adds the Activity model and creates a polymorphic association with Rooms and Jams.
* https://github.com/tomekr/jamroulette/commit/ee928204ff9d932079ca3299fca6984991611267 Utilizes the ActivityPresenter created in https://github.com/tomekr/jamroulette/commit/ecdb82027ca20e890944971105ce19e776e1b235.

