### PR TITLE
Use SendGrid for production email

### DIFF
--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,4 +1,0 @@
-class ApplicationMailer < ActionMailer::Base
-  default from: 'from@example.com'
-  layout 'mailer'
-end

--- a/app/mailers/staging_email_interceptor.rb
+++ b/app/mailers/staging_email_interceptor.rb
@@ -1,0 +1,5 @@
+class StagingEmailInterceptor
+  def self.delivering_email(mail)
+    mail.subject.prepend('[STAGING] ')
+  end
+end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -76,7 +76,7 @@ Rails.application.configure do
     :authentication => :plain,
     :user_name      => ENV['SENDGRID_USERNAME'],
     :password       => ENV['SENDGRID_PASSWORD'],
-    :domain         => 'heroku.com',
+    :domain         => 'jamroulette.app',
     :enable_starttls_auto => true
   }
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -65,14 +65,22 @@ Rails.application.configure do
   # config.active_job.queue_adapter     = :resque
   # config.active_job.queue_name_prefix = "jamroulette_production"
 
+  config.action_mailer.raise_delivery_errors = true
+  config.action_mailer.delivery_method = :smtp
   host = ENV['HOSTNAME'] || 'example.com'
   config.action_mailer.default_url_options = { host: host }
 
-  config.action_mailer.perform_caching = false
+  ActionMailer::Base.smtp_settings = {
+    :address        => 'smtp.sendgrid.net',
+    :port           => '587',
+    :authentication => :plain,
+    :user_name      => ENV['SENDGRID_USERNAME'],
+    :password       => ENV['SENDGRID_PASSWORD'],
+    :domain         => 'heroku.com',
+    :enable_starttls_auto => true
+  }
 
-  # Ignore bad email addresses and do not raise email delivery errors.
-  # Set this to true and configure the email server for immediate delivery to raise delivery errors.
-  # config.action_mailer.raise_delivery_errors = false
+  config.action_mailer.perform_caching = false
 
   # Enable locale fallbacks for I18n (makes lookups for any locale fall back to
   # the I18n.default_locale when a translation cannot be found).

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -18,7 +18,7 @@ Devise.setup do |config|
   # Configure the e-mail address which will be shown in Devise::Mailer,
   # note that it will be overwritten if you use your own mailer class
   # with default "from" parameter.
-  config.mailer_sender = 'please-change-me-at-config-initializers-devise@example.com'
+  config.mailer_sender = 'noreply@jamroulette.app'
 
   # Configure the class responsible to send e-mails.
   # config.mailer = 'Devise::Mailer'

--- a/config/initializers/staging_email_interceptor.rb
+++ b/config/initializers/staging_email_interceptor.rb
@@ -1,0 +1,9 @@
+if ENV['STAGING']
+  class StagingEmailInterceptor
+    def self.delivering_email(mail)
+      mail.subject.prepend('[STAGING] ')
+    end
+  end
+
+  ActionMailer::Base.register_interceptor(StagingEmailInterceptor)
+end

--- a/config/initializers/staging_email_interceptor.rb
+++ b/config/initializers/staging_email_interceptor.rb
@@ -1,9 +1,3 @@
 if ENV['STAGING']
-  class StagingEmailInterceptor
-    def self.delivering_email(mail)
-      mail.subject.prepend('[STAGING] ')
-    end
-  end
-
   ActionMailer::Base.register_interceptor(StagingEmailInterceptor)
 end

--- a/spec/mailers/staging_email_interceptor_spec.rb
+++ b/spec/mailers/staging_email_interceptor_spec.rb
@@ -1,0 +1,15 @@
+require "rails_helper"
+
+RSpec.describe StagingEmailInterceptor do
+  subject(:interceptor) { described_class }
+
+  describe '#delivering_email' do
+    let(:mail) { Mail::Message.new(subject: 'test-subject') }
+
+    it 'prepends [STAGING] to subject' do
+      expect do
+        interceptor.delivering_email(mail)
+      end.to change { mail.subject }.from('test-subject').to('[STAGING] test-subject')
+    end
+  end
+end


### PR DESCRIPTION
https://github.com/tomekr/jamroulette/commit/230994877c86a959522877494e1f312b061da922 adds the required configuration. 
https://github.com/tomekr/jamroulette/commit/a47edccaf922df711aea26903f0a80de585d8166 adds an [email interceptor](https://guides.rubyonrails.org/action_mailer_basics.html#intercepting-and-observing-emails) in staging to prepend the string `[STAGING]` to email subjects.

# Pre-Deploy Checklist

## Staging
- [x] `STAGING ` env var set to `true`
- [x] `HOSTNAME` env var set
- [x] `SENDGRID_USERNAME ` env var set
- [x] `SENDGRID_PASSWORD ` env var set
- [ ] Deploy and verify email is working correctly

## Production
- [x] `HOSTNAME` env var set
- [x] `SENDGRID_USERNAME ` env var set
- [x] `SENDGRID_PASSWORD ` env var set