### PR TITLE
Require room name during room creation

### DIFF
--- a/app/controllers/rooms_controller.rb
+++ b/app/controllers/rooms_controller.rb
@@ -13,12 +13,22 @@ class RoomsController < ApplicationController
 
   # POST /rooms
   def create
-    room = Room.create!
-    room.activities.create!(user: current_user)
-    redirect_to room_path(room)
+    room = Room.new(room_parms)
+
+    if room.save
+      room.activities.create!(user: current_user)
+      redirect_to room_path(room)
+    else
+      flash.alert = room.errors.full_messages.join(', ')
+      redirect_back fallback_location: home_path
+    end
   end
 
   private
+
+  def room_parms
+    params.require(:room).permit(:name)
+  end
 
   def set_room
     @room = Room.find_by!(public_id: params[:id])

--- a/app/controllers/rooms_controller.rb
+++ b/app/controllers/rooms_controller.rb
@@ -13,7 +13,7 @@ class RoomsController < ApplicationController
 
   # POST /rooms
   def create
-    room = Room.new(room_parms)
+    room = current_user.rooms.build(room_parms)
 
     if room.save
       room.activities.create!(user: current_user)

--- a/app/javascript/packs/create_room_modal.ts
+++ b/app/javascript/packs/create_room_modal.ts
@@ -1,0 +1,67 @@
+class CreateRoomModal {
+  modal: HTMLElement
+  createButton: HTMLElement
+  closeButtons: NodeListOf<HTMLElement>
+  nameInput: HTMLInputElement
+  roomForm: HTMLFormElement
+
+  constructor(modal: HTMLElement) {
+    this.modal = modal
+    this.createButton = this.modal.querySelector("#room-create-create-btn")
+    this.closeButtons = this.modal.querySelectorAll(".modal-close-btn")
+    this.roomForm = this.modal.querySelector("#room-form")
+    this.nameInput = this.modal.querySelector("#room_name")
+  }
+
+  initHandlers(): void {
+    // show the modal
+    this.modal.classList.add('is-active');
+
+    // Because turbolinks doesn't reload the page we have to clear the input
+    this.nameInput.value = ''
+    // send focus to the name input field
+    this.nameInput.focus()
+
+    // set on click listeners
+    this.onCloseButtonClick()
+    this.onRoomFormSubmit()
+    this.onEnterKeyPressed()
+  }
+
+  onEnterKeyPressed(): void {
+    this.nameInput.addEventListener('keydown', (event) => {
+      if (event.keyCode === 13) {
+        event.preventDefault();
+        this.roomForm.submit()
+      }
+    })
+  }
+  onRoomFormSubmit(): void {
+    this.roomForm.addEventListener('submit', () => {
+      this.closeModal()
+    })
+  }
+
+  onCloseButtonClick(): void {
+    this.closeButtons.forEach(closeElement => {
+      closeElement.addEventListener("click", (event) => {
+        event.preventDefault()
+        this.closeModal()
+      })
+    })
+  }
+
+  closeModal(): void {
+    this.modal.classList.remove('is-active')
+  }
+}
+
+document.addEventListener("turbolinks:load", () => {
+  document.querySelectorAll(".create-room-button").forEach(createRoomButton => {
+    // Show modal when a "Create room" button is clicked
+    createRoomButton.addEventListener('click', () => {
+      const createRoomModal = document.querySelector('#create-room-modal') as HTMLElement
+      new CreateRoomModal(createRoomModal).initHandlers()
+    })
+  })
+})

--- a/app/models/jam.rb
+++ b/app/models/jam.rb
@@ -2,7 +2,7 @@
 
 class Jam < ApplicationRecord
   belongs_to :room
-  belongs_to :user, optional: true
+  belongs_to :user
   has_one_attached :file
   validates :file, presence: { message: "must be attached" }
   validate :content_type_is_audio

--- a/app/models/room.rb
+++ b/app/models/room.rb
@@ -5,7 +5,7 @@ class Room < ApplicationRecord
   validates :name, presence: true
   after_initialize :generate_public_id
 
-  belongs_to :user, optional: true
+  belongs_to :user
 
   has_many :jams, dependent: :destroy
   has_many :activities, as: :subject, dependent: :destroy

--- a/app/models/room.rb
+++ b/app/models/room.rb
@@ -5,6 +5,8 @@ class Room < ApplicationRecord
   validates :name, presence: true
   after_initialize :generate_public_id
 
+  belongs_to :user, optional: true
+
   has_many :jams, dependent: :destroy
   has_many :activities, as: :subject, dependent: :destroy
 

--- a/app/models/room.rb
+++ b/app/models/room.rb
@@ -2,6 +2,7 @@
 
 class Room < ApplicationRecord
   validates :public_id, uniqueness: true
+  validates :name, presence: true
   after_initialize :generate_public_id
 
   has_many :jams, dependent: :destroy

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,5 +5,7 @@ class User < ApplicationRecord
          :recoverable, :rememberable, :validatable,
          :confirmable, :trackable
   has_many :jams, dependent: :restrict_with_exception
+  has_many :rooms, dependent: :restrict_with_exception
+
   has_many :activities, dependent: :destroy
 end

--- a/app/views/layouts/_navbar.html.erb
+++ b/app/views/layouts/_navbar.html.erb
@@ -15,12 +15,12 @@
         <div class="navbar-item">
           <div class="buttons">
           <% if user_signed_in? %>
-            <%= link_to(rooms_path, method: :post, class: "button is-primary is-inverted") do %>
+            <button class="button is-primary is-inverted create-room-button">
               <span class="icon">
                 <i class="fas fa-plus-circle"></i>
               </span>
               <span>Create Room</span>
-            <% end %>
+            </button>
             <%= link_to(destroy_user_session_path, method: :delete,  class: "button is-primary is-inverted") do %>
               <span class="icon">
                 <i class="fas fa-user"></i>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -9,9 +9,11 @@
     
     <%= stylesheet_pack_tag("application") %>
     <%= javascript_pack_tag 'application', 'data-turbolinks-track': 'reload' %>
+    <%= javascript_pack_tag 'create_room_modal' %>
   </head>
 
   <%= render "layouts/navbar" %>
+  <%= render "shared/create_room_modal" %>
 
   <body>
     <%= render "layouts/flash" %>

--- a/app/views/rooms/show.html.erb
+++ b/app/views/rooms/show.html.erb
@@ -1,6 +1,6 @@
 <section class="section" id="room-header">
   <div id="breadcrumb">
-    <%= "Home/#{@room.public_id}"%>
+    <%= "Home/#{@room.name}"%>
   </div>
   <div id="share-this-room">
     Share this Room: <%= link_to room_url(@room) %>

--- a/app/views/shared/_create_room_modal.html.erb
+++ b/app/views/shared/_create_room_modal.html.erb
@@ -1,0 +1,25 @@
+<div id="create-room-modal" class="modal">
+  <div class="modal-background"></div>
+  <div class="modal-card">
+    <%= form_with model: Room, id: 'room-form', local: true do |f| %>
+      <header class="modal-card-head">
+        <p class="modal-card-title">Give your room a name</p>
+        <button class="delete modal-close-btn" aria-label="close"></button>
+      </header>
+
+      <section class="modal-card-body">
+        <div class="field">
+          <label class="label">Name</label>
+          <div class="control">
+            <%= f.text_field :name, class: 'input' %>
+          </div>
+        </div>
+      </section>
+
+      <footer class="modal-card-foot">
+        <%= f.submit "Create", id: 'room-create-create-btn', class: 'button is-success' %>
+        <button class="button modal-close-btn">Cancel</button>
+      </footer>
+    <% end %>
+  </div>
+</div>

--- a/app/views/static/index.html.erb
+++ b/app/views/static/index.html.erb
@@ -18,12 +18,12 @@
           <% end %>
         <% end %>
 
-        <%= link_to(rooms_path, method: :post, class: "button is-primary is-inverted") do %>
+        <button class="button is-primary is-inverted create-room-button">
           <span class="icon">
             <i class="fas fa-plus-circle"></i>
           </span>
           <span>Create a new room</span>
-        <% end %>
+        </button>
       </section>
 
       <% if @current_user&.activities&.any? %>

--- a/db/migrate/20200330212553_change_room_title_to_name.rb
+++ b/db/migrate/20200330212553_change_room_title_to_name.rb
@@ -1,0 +1,5 @@
+class ChangeRoomTitleToName < ActiveRecord::Migration[6.0]
+  def change
+    rename_column :rooms, :title, :name
+  end
+end

--- a/db/migrate/20200331183524_add_user_ref_to_rooms.rb
+++ b/db/migrate/20200331183524_add_user_ref_to_rooms.rb
@@ -1,0 +1,5 @@
+class AddUserRefToRooms < ActiveRecord::Migration[6.0]
+  def change
+    add_reference :rooms, :user, null: true, foreign_key: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_03_30_212553) do
+ActiveRecord::Schema.define(version: 2020_03_31_183524) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -68,7 +68,9 @@ ActiveRecord::Schema.define(version: 2020_03_30_212553) do
     t.citext "public_id", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.bigint "user_id"
     t.index ["public_id"], name: "index_rooms_on_public_id", unique: true
+    t.index ["user_id"], name: "index_rooms_on_user_id"
   end
 
   create_table "users", force: :cascade do |t|
@@ -98,4 +100,5 @@ ActiveRecord::Schema.define(version: 2020_03_30_212553) do
   add_foreign_key "activities", "users"
   add_foreign_key "jams", "rooms"
   add_foreign_key "jams", "users"
+  add_foreign_key "rooms", "users"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_03_29_191513) do
+ActiveRecord::Schema.define(version: 2020_03_30_212553) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -64,7 +64,7 @@ ActiveRecord::Schema.define(version: 2020_03_29_191513) do
   end
 
   create_table "rooms", force: :cascade do |t|
-    t.string "title"
+    t.string "name"
     t.citext "public_id", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false

--- a/spec/factories/jam_factory.rb
+++ b/spec/factories/jam_factory.rb
@@ -5,5 +5,6 @@ FactoryBot.define do
     bpm { '120' }
     file { fixture_file_upload(Rails.root.join('spec', 'support', 'assets', 'test.mp3'), 'audio/mpeg') }
     room
+    user
   end
 end

--- a/spec/factories/room_factory.rb
+++ b/spec/factories/room_factory.rb
@@ -3,5 +3,6 @@
 FactoryBot.define do
   factory :room do
     name { 'Room 1' }
+    user
   end
 end

--- a/spec/factories/room_factory.rb
+++ b/spec/factories/room_factory.rb
@@ -2,6 +2,6 @@
 
 FactoryBot.define do
   factory :room do
-    title { 'Room 1' }
+    name { 'Room 1' }
   end
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,7 +1,9 @@
 FactoryBot.define do
   factory :user do
+    sequence :email do |n|
+      "person#{n}@example.com"
+    end
     display_name { "Bobby" }
-    email { "bob@example.com" }
     password { "password" }
     password_confirmation { "password" }
     confirmed_at { Date.today }

--- a/spec/helpers/rooms_helper_spec.rb
+++ b/spec/helpers/rooms_helper_spec.rb
@@ -4,8 +4,8 @@ RSpec.describe RoomsHelper, :type => :helper do
   describe "#jam_user" do
     context "user exists" do
       it "returns the users display name" do
-        user = create(:user, display_name: "Bobby")
-        jam = create(:jam, user: user)
+        user = build(:user, display_name: "Bobby")
+        jam = build(:jam, user: user)
 
         expect(helper.jam_user(jam)).to eq("Bobby")
       end
@@ -13,7 +13,7 @@ RSpec.describe RoomsHelper, :type => :helper do
 
     context "user does not exist" do
       it 'returns Anonymous' do
-        jam = create(:jam, user: nil)
+        jam = build(:jam, user: nil)
 
         expect(helper.jam_user(jam)).to eq("Anonymous")
       end

--- a/spec/models/room_spec.rb
+++ b/spec/models/room_spec.rb
@@ -11,6 +11,10 @@ RSpec.describe Room, type: :model do
     it 'is valid out of the factory' do
       expect(room).to be_valid
     end
+
+    it 'requires a room name' do
+      expect(build(:room, name: "")).to_not be_valid
+    end
   end
 
   it 'generates a random hex room hash' do

--- a/spec/models/room_spec.rb
+++ b/spec/models/room_spec.rb
@@ -13,7 +13,8 @@ RSpec.describe Room, type: :model do
     end
 
     it 'requires a room name' do
-      expect(build(:room, name: "")).to_not be_valid
+      room.name = ''
+      expect(room).to_not be_valid
     end
   end
 

--- a/spec/requests/controllers/rooms_controller_spec.rb
+++ b/spec/requests/controllers/rooms_controller_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe RoomsController, type: :request do
@@ -23,7 +25,7 @@ RSpec.describe RoomsController, type: :request do
   end
 
   describe 'POST #create' do
-    it_behaves_like "Auth Required"
+    it_behaves_like 'Auth Required'
     let(:room) { build(:room) }
     let(:action) do
       post rooms_path, params: {
@@ -33,7 +35,6 @@ RSpec.describe RoomsController, type: :request do
 
     let(:user) { create(:user) }
     before { sign_in(user) }
-
 
     it 'creates a room' do
       expect { action }.to change(Room, :count).by(1)
@@ -58,8 +59,10 @@ RSpec.describe RoomsController, type: :request do
     context 'invalid room' do
       let(:room) { build(:room, name: '') }
 
-      it 'does not create a room without a name' do
-        expect { action }.to_not change(Activity, :count)
+      it 'redirects to previous page with error' do
+        post rooms_path, params: { room: { name: room.name } },
+                         headers: { 'Referer': '/previous_page' }
+        expect(response).to redirect_to('/previous_page')
       end
     end
   end

--- a/spec/requests/controllers/rooms_controller_spec.rb
+++ b/spec/requests/controllers/rooms_controller_spec.rb
@@ -64,6 +64,11 @@ RSpec.describe RoomsController, type: :request do
                          headers: { 'Referer': '/previous_page' }
         expect(response).to redirect_to('/previous_page')
       end
+
+      it 'adds error to flash' do
+        action
+        expect(flash.alert).to include("Name can't be blank")
+      end
     end
   end
 end

--- a/spec/requests/controllers/rooms_controller_spec.rb
+++ b/spec/requests/controllers/rooms_controller_spec.rb
@@ -24,7 +24,12 @@ RSpec.describe RoomsController, type: :request do
 
   describe 'POST #create' do
     it_behaves_like "Auth Required"
-    let(:action) { post rooms_path }
+    let(:room) { build(:room) }
+    let(:action) do
+      post rooms_path, params: {
+        room: { name: room.name }
+      }
+    end
 
     let(:user) { create(:user) }
     before { sign_in(user) }
@@ -42,6 +47,14 @@ RSpec.describe RoomsController, type: :request do
       action
       room = Room.last
       expect(room.activities.take.user).to eq user
+    end
+
+    context 'invalid room' do
+      let(:room) { build(:room, name: '') }
+
+      it 'does not create a room without a name' do
+        expect { action }.to_not change(Activity, :count)
+      end
     end
   end
 end

--- a/spec/requests/controllers/rooms_controller_spec.rb
+++ b/spec/requests/controllers/rooms_controller_spec.rb
@@ -39,6 +39,12 @@ RSpec.describe RoomsController, type: :request do
       expect { action }.to change(Room, :count).by(1)
     end
 
+    it 'associates the room with the current user' do
+      action
+      room = Room.last
+      expect(room.user).to eq user
+    end
+
     it 'creates an activity' do
       expect { action }.to change(Activity, :count).by(1)
     end

--- a/spec/requests/rooms_request_spec.rb
+++ b/spec/requests/rooms_request_spec.rb
@@ -13,21 +13,6 @@ RSpec.describe 'Room viewing', type: :request do
   let(:room) { build(:room) }
   let(:room_params) { { room: { name: room.name } } }
 
-  context "user is authenticated" do
-    before { sign_in create(:user) }
-    let(:room) { build(:room, name: nil) }
-
-    context 'invalid room' do
-      let(:room) { build(:room, name: '') }
-
-      it 'displays an error if a name is not provided' do
-        post rooms_path, params: room_params
-        follow_redirect!
-        expect(flash.alert).to include("Name can't be blank")
-      end
-    end
-  end
-
   context "user is unauthenticated" do
     it 'redirects user to sign in page' do
       post rooms_path, params: room_params

--- a/spec/requests/rooms_request_spec.rb
+++ b/spec/requests/rooms_request_spec.rb
@@ -20,11 +20,6 @@ RSpec.describe 'Room viewing', type: :request do
     context 'invalid room' do
       let(:room) { build(:room, name: '') }
 
-      it 'redirects to the previous page user was on' do
-        post rooms_path, params: room_params, headers: { 'Referer': '/previous_page' }
-        expect(response).to redirect_to('/previous_page')
-      end
-
       it 'displays an error if a name is not provided' do
         post rooms_path, params: room_params
         follow_redirect!

--- a/spec/requests/rooms_request_spec.rb
+++ b/spec/requests/rooms_request_spec.rb
@@ -9,13 +9,33 @@ RSpec.describe 'Room viewing', type: :request do
     post '/validate_beta_user', params: { beta_code: 'correct-code' }
   end
 
-  let(:room) { create(:room) }
   let(:current_jam) { create(:jam, room: room) }
+  let(:room) { build(:room) }
+  let(:room_params) { { room: { name: room.name } } }
 
+  context "user is authenticated" do
+    before { sign_in create(:user) }
+    let(:room) { build(:room, name: nil) }
+
+    context 'invalid room' do
+      let(:room) { build(:room, name: '') }
+
+      it 'redirects to the previous page user was on' do
+        post rooms_path, params: room_params, headers: { 'Referer': '/previous_page' }
+        expect(response).to redirect_to('/previous_page')
+      end
+
+      it 'displays an error if a name is not provided' do
+        post rooms_path, params: room_params
+        follow_redirect!
+        expect(flash.alert).to include("Name can't be blank")
+      end
+    end
+  end
 
   context "user is unauthenticated" do
     it 'redirects user to sign in page' do
-      post rooms_path
+      post rooms_path, params: room_params
       expect(response).to redirect_to(new_user_session_path)
     end
   end
@@ -45,7 +65,8 @@ RSpec.describe 'Room viewing', type: :request do
     expect(response.body).to include(previous_jam_path)
   end
 
-  it 'does not display Jam attributes one does not exist' do
+  it 'does not display Jam attributes if they do not exist' do
+    room = create(:room)
     get room_path(room)
 
     expect(response.body).to_not include('Latest JAM')

--- a/spec/system/home_page_spec.rb
+++ b/spec/system/home_page_spec.rb
@@ -52,9 +52,13 @@ RSpec.describe 'visiting the home page', type: :system do
 
       it 'allows a user to create a new room' do
         visit home_path
-        click_on('Create a new room')
+        click_on 'Create a new room'
+
+        fill_in :room_name, with: 'test-room'
+        click_button 'Create'
 
         expect(page).to have_content('Upload a track to get started')
+        expect(page).to have_content('test-room')
       end
 
       it 'allows a user to sign out' do


### PR DESCRIPTION
https://github.com/tomekr/jamroulette/commit/cced04a498a4f3b539c786ef7ad3aef11453dfa4 changes Room title to name (this just felt better to me)

With "Create Room" being a button in the navbar, we now have a shared modal that is required on every page. [create_room_modal.ts](https://github.com/tomekr/jamroulette/compare/room-names?expand=1#diff-e0886c2efc75534575b4d56057274ade) contains the logic for displaying and handling form submissions.

Turbolinks complicated things a bit here, as a result we have to do [some housekeeping](https://github.com/tomekr/jamroulette/compare/room-names?expand=1#diff-e0886c2efc75534575b4d56057274adeR20-R21) to ensure the form is cleared. For example, with turbolinks when you create a room on the home page and are redirected to the room page, the modal form will still contain the users input.

![room-name-modal](https://user-images.githubusercontent.com/723637/78058238-9c4a1c00-734d-11ea-9309-0c27ebb4ced3.png)
