### PR TITLE
Upload new track button bug

### DIFF
--- a/app/views/rooms/show.html.erb
+++ b/app/views/rooms/show.html.erb
@@ -129,7 +129,7 @@
   </div>
 </section>
 
-<div class="modal">
+<div id="upload-track-modal" class="modal">
   <div class="modal-background"></div>
   <div class="modal-card">
     <%= form_with(model: @new_jam, url: [@room, @new_jam],  multipart: true,  local: true) do |form| %>
@@ -174,7 +174,7 @@
   uploadJamButton.onclick = (event) => {
     event.preventDefault();
   
-    const modal = document.querySelector('.modal');  // assuming you have only 1
+    const modal = document.querySelector('#upload-track-modal');
     const html = document.querySelector('html');
     modal.classList.add('is-active');
     html.classList.add('is-clipped');

--- a/spec/support/system.rb
+++ b/spec/support/system.rb
@@ -1,7 +1,27 @@
 # frozen_string_literal: true
 
+# Setup chrome headless driver for docker compatability
+Capybara.server = :puma, { Silent: true }
+
+Capybara.register_driver :chrome_headless do |app|
+  options = ::Selenium::WebDriver::Chrome::Options.new
+
+  options.add_argument('--headless')
+  options.add_argument('--no-sandbox')
+  options.add_argument('--disable-dev-shm-usage')
+  options.add_argument('--window-size=1400,1400')
+
+  Capybara::Selenium::Driver.new(app, browser: :chrome, options: options)
+end
+
+Capybara.javascript_driver = :chrome_headless
+
 RSpec.configure do |config|
   config.before(:each, type: :system) do
     driven_by :rack_test
+  end
+
+  config.before(:each, type: :system, js: true) do
+    driven_by :chrome_headless
   end
 end

--- a/spec/system/home_page_spec.rb
+++ b/spec/system/home_page_spec.rb
@@ -68,6 +68,18 @@ RSpec.describe 'visiting the home page', type: :system do
         expect(page).to have_content('Signed out successfully')
       end
 
+      it 'allows a user to upload a jam', js: true do
+        room = create(:room)
+        visit room_path(room)
+        click_on 'Upload New Track'
+
+        fill_in :jam_bpm, with: '120', visible: true
+        attach_file :jam_file, 'spec/support/assets/test.mp3', make_visible: true
+        click_on 'Upload'
+
+        expect(page).to have_content('Jam successfully created!')
+      end
+
       context 'activity feed' do
         it 'allows user to view a jam they uploaded' do
           activity = create(:activity, :jam, user: user)


### PR DESCRIPTION
Fixes #34 

Note, we're unable to use the standard `selenium_chrome_headless` adapter because this breaks inside of a docker container. See https://stackoverflow.com/questions/50610316/capybara-headless-chrome-in-docker-returns-devtoolsactiveport-file-doesnt-exist