### PR TITLE
Display Notifications in UI with ability to mark them as read

### DIFF
--- a/app/controllers/concerns/trackable.rb
+++ b/app/controllers/concerns/trackable.rb
@@ -1,0 +1,13 @@
+module Trackable
+  extend ActiveSupport::Concern
+
+  included do
+    after_create :create_activity
+  end
+
+  private
+
+  def create_activity
+    activities.create!(user: user)
+  end
+end

--- a/app/controllers/jams_controller.rb
+++ b/app/controllers/jams_controller.rb
@@ -10,11 +10,13 @@ class JamsController < ApplicationController
 
     if jam.save
       jam.activities.create!(user: current_user)
-      notification = jam.notifications.create!(
-        user: jam.room.user,
-        notify_type: :jam_created,
-        actor: jam.user
-      )
+      room.users.reject{|user| user == current_user }.each do |user|
+        NotificationService.notify(
+          subject: jam,
+          user: user,
+          event: :jam_created
+        )
+      end
 
       flash[:success] = 'Jam successfully created!'
     else

--- a/app/controllers/jams_controller.rb
+++ b/app/controllers/jams_controller.rb
@@ -10,6 +10,12 @@ class JamsController < ApplicationController
 
     if jam.save
       jam.activities.create!(user: current_user)
+      notification = jam.notifications.create!(
+        user: jam.room.user,
+        notify_type: :jam_created,
+        actor: jam.user
+      )
+
       flash[:success] = 'Jam successfully created!'
     else
       flash[:danger] = jam.errors.full_messages.join(', ')

--- a/app/controllers/jams_controller.rb
+++ b/app/controllers/jams_controller.rb
@@ -9,7 +9,6 @@ class JamsController < ApplicationController
     jam.user = current_user
 
     if jam.save
-      jam.activities.create!(user: current_user)
       room.users.reject{|user| user == current_user }.each do |user|
         NotificationService.notify(
           subject: jam,

--- a/app/controllers/notifications_controller.rb
+++ b/app/controllers/notifications_controller.rb
@@ -1,23 +1,19 @@
 class NotificationsController < ApplicationController
-  before_action :set_room
+  before_action :set_notifications
 
   def index
-    respond_to do |format|
-      format.json { render json: @notifications }
-    end
+    render json: @notifications
   end
 
   def read
-    @notifications.update_all(read_at: Time.now)
+    @notifications.update_all(read_at: Time.current)
 
-    respond_to do |format|
-      format.json { render json: "OK" }
-    end
+    render json: "OK"
   end
 
   private
 
-  def set_room
+  def set_notifications
     @notifications = current_user.notifications.unread
   end
 end

--- a/app/controllers/notifications_controller.rb
+++ b/app/controllers/notifications_controller.rb
@@ -7,9 +7,17 @@ class NotificationsController < ApplicationController
     end
   end
 
+  def read
+    @notifications.update_all(read_at: Time.now)
+
+    respond_to do |format|
+      format.json { render json: "OK" }
+    end
+  end
+
   private
 
   def set_room
-    @notifications = current_user.notifications
+    @notifications = current_user.notifications.unread
   end
 end

--- a/app/controllers/notifications_controller.rb
+++ b/app/controllers/notifications_controller.rb
@@ -1,0 +1,15 @@
+class NotificationsController < ApplicationController
+  before_action :set_room
+
+  def index
+    respond_to do |format|
+      format.json { render json: @notifications }
+    end
+  end
+
+  private
+
+  def set_room
+    @notifications = current_user.notifications
+  end
+end

--- a/app/controllers/rooms_controller.rb
+++ b/app/controllers/rooms_controller.rb
@@ -16,7 +16,6 @@ class RoomsController < ApplicationController
     room = current_user.rooms.build(room_parms)
 
     if room.save
-      room.activities.create!(user: current_user)
       redirect_to room_path(room)
     else
       flash.alert = room.errors.full_messages.join(', ')

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -11,4 +11,9 @@ module ApplicationHelper
   def beta_user?
     session[:is_beta_user].present?
   end
+
+  def has_unread_notifications?(user)
+    return false unless user
+    user.notifications.unread.present?
+  end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -14,6 +14,6 @@ module ApplicationHelper
 
   def has_unread_notifications?(user)
     return false unless user
-    user.notifications.unread.present?
+    user.notifications.unread.any?
   end
 end

--- a/app/javascript/packs/notification_feed.ts
+++ b/app/javascript/packs/notification_feed.ts
@@ -1,11 +1,11 @@
-document.addEventListener("turbolinks:load", () => {
+document.addEventListener("DOMContentLoaded", () => {
   // Show modal when a "Create room" button is clicked
   document.querySelector("#notifications").addEventListener('click', (event) => {
     console.log('clicked')
 
     // Toggle feed list
-    const feed = document.querySelector('.notification-feed') as HTMLElement
-    feed.classList.toggle('is-hidden')
+    const feed = document.querySelector('#notifications') as HTMLElement
+    feed.classList.toggle('is-active')
 
     // Remove counter tag
     const counter = document.querySelector(".notification-counter") as HTMLElement

--- a/app/javascript/packs/notification_feed.ts
+++ b/app/javascript/packs/notification_feed.ts
@@ -1,0 +1,32 @@
+document.addEventListener("turbolinks:load", () => {
+  // Show modal when a "Create room" button is clicked
+  document.querySelector("#notifications").addEventListener('click', (event) => {
+    console.log('clicked')
+
+    // Toggle feed list
+    const feed = document.querySelector('.notification-feed') as HTMLElement
+    feed.classList.toggle('is-hidden')
+
+    // Remove counter tag
+    const counter = document.querySelector(".notification-counter") as HTMLElement
+    counter.classList.replace('is-danger', 'is-primary')
+    counter.innerHTML = '0'
+
+    const notificationsContainer = document.querySelector("#notifications") as HTMLElement
+
+    if (!notificationsContainer.classList.contains('read')) {
+      // Mark notifications as read
+      const userId = notificationsContainer.dataset.userId
+      const token = document.querySelector('meta[name="csrf-token"]') as HTMLMetaElement
+      fetch(`/users/${userId}/notifications/read`, {
+        credentials: 'include',
+        method: 'PUT',
+        headers: {
+          'X-CSRF-Token': token.content
+        }
+      })
+
+      notificationsContainer.classList.add('read')
+    }
+  })
+})

--- a/app/javascript/styles/_custom.scss
+++ b/app/javascript/styles/_custom.scss
@@ -1,4 +1,1 @@
 $primary: #611986; 
-// This appears to be required because of a current bug in bulma
-// https://github.com/jgthms/bulma/pull/2743
-$input-color: hsl(0, 0%, 21%);

--- a/app/javascript/styles/styles.scss
+++ b/app/javascript/styles/styles.scss
@@ -6,5 +6,9 @@
 @import '~bulma'; 
 
 #notifications {
-  cursor: pointer
+  cursor: pointer;
+}
+
+.notifications-box {
+  margin: $navbar-height;
 }

--- a/app/javascript/styles/styles.scss
+++ b/app/javascript/styles/styles.scss
@@ -4,3 +4,7 @@
 @import "custom";
 
 @import '~bulma'; 
+
+#notifications {
+  cursor: pointer
+}

--- a/app/javascript/styles/styles.scss
+++ b/app/javascript/styles/styles.scss
@@ -9,6 +9,7 @@
   cursor: pointer;
 }
 
-.notifications-box {
-  margin: $navbar-height;
+.notification-feed {
+  min-width: 15em;
+  padding-top: 15px;
 }

--- a/app/models/jam.rb
+++ b/app/models/jam.rb
@@ -10,7 +10,13 @@ class Jam < ApplicationRecord
   has_many :activities, as: :subject, dependent: :destroy
   has_many :notifications, as: :target, dependent: :destroy
 
+  after_create :create_activity
+
   private
+
+  def create_activity
+    activities.create!(user: user)
+  end
 
   def content_type_is_audio
     return unless file.attached?

--- a/app/models/jam.rb
+++ b/app/models/jam.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class Jam < ApplicationRecord
+  include Trackable
+
   belongs_to :room
   belongs_to :user
   has_one_attached :file
@@ -10,13 +12,7 @@ class Jam < ApplicationRecord
   has_many :activities, as: :subject, dependent: :destroy
   has_many :notifications, as: :target, dependent: :destroy
 
-  after_create :create_activity
-
   private
-
-  def create_activity
-    activities.create!(user: user)
-  end
 
   def content_type_is_audio
     return unless file.attached?

--- a/app/models/jam.rb
+++ b/app/models/jam.rb
@@ -8,6 +8,7 @@ class Jam < ApplicationRecord
   validate :content_type_is_audio
 
   has_many :activities, as: :subject, dependent: :destroy
+  has_many :notifications, as: :target, dependent: :destroy
 
   private
 

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -1,0 +1,7 @@
+class Notification < ApplicationRecord
+  belongs_to :actor, class_name: "User"
+  belongs_to :user
+  belongs_to :target, polymorphic: true, optional: true
+
+  scope :unread, -> { where(read_at: nil) }
+end

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -1,5 +1,4 @@
 class Notification < ApplicationRecord
-  belongs_to :actor, class_name: "User"
   belongs_to :user
   belongs_to :target, polymorphic: true, optional: true
 

--- a/app/models/room.rb
+++ b/app/models/room.rb
@@ -9,6 +9,7 @@ class Room < ApplicationRecord
 
   has_many :jams, dependent: :destroy
   has_many :activities, as: :subject, dependent: :destroy
+  has_many :notifications, as: :target, dependent: :destroy
 
   scope :recommended, -> { joins(:jams).order("RANDOM()") }
 

--- a/app/models/room.rb
+++ b/app/models/room.rb
@@ -15,11 +15,17 @@ class Room < ApplicationRecord
 
   scope :recommended, -> { joins(:jams).order("RANDOM()") }
 
+  after_create :create_activity
+
   def to_param
     public_id
   end
 
   private
+
+  def create_activity
+    activities.create!(user: user)
+  end
 
   def generate_public_id
     self.public_id ||= SecureRandom.hex

--- a/app/models/room.rb
+++ b/app/models/room.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class Room < ApplicationRecord
+  include Trackable
+
   validates :public_id, uniqueness: true
   validates :name, presence: true
   after_initialize :generate_public_id
@@ -15,17 +17,11 @@ class Room < ApplicationRecord
 
   scope :recommended, -> { joins(:jams).order("RANDOM()") }
 
-  after_create :create_activity
-
   def to_param
     public_id
   end
 
   private
-
-  def create_activity
-    activities.create!(user: user)
-  end
 
   def generate_public_id
     self.public_id ||= SecureRandom.hex

--- a/app/models/room.rb
+++ b/app/models/room.rb
@@ -8,6 +8,8 @@ class Room < ApplicationRecord
   belongs_to :user
 
   has_many :jams, dependent: :destroy
+  has_many :users, through: :jams
+
   has_many :activities, as: :subject, dependent: :destroy
   has_many :notifications, as: :target, dependent: :destroy
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -8,4 +8,5 @@ class User < ApplicationRecord
   has_many :rooms, dependent: :restrict_with_exception
 
   has_many :activities, dependent: :destroy
+  has_many :notifications, dependent: :destroy
 end

--- a/app/services/notification_service.rb
+++ b/app/services/notification_service.rb
@@ -1,0 +1,9 @@
+class NotificationService
+  def self.notify(subject:, user:, event:)
+    notification = subject.notifications.create!(
+      user: user,
+      notify_type: event,
+      actor: subject.user
+    )
+  end
+end

--- a/app/services/notification_service.rb
+++ b/app/services/notification_service.rb
@@ -2,8 +2,7 @@ class NotificationService
   def self.notify(subject:, user:, event:)
     notification = subject.notifications.create!(
       user: user,
-      notify_type: event,
-      actor: subject.user
+      event: event,
     )
   end
 end

--- a/app/views/layouts/_navbar.html.erb
+++ b/app/views/layouts/_navbar.html.erb
@@ -13,6 +13,24 @@
 
       <div class="navbar-end">
         <div class="navbar-item">
+          <% if has_unread_notifications?(current_user) %>
+            <div id="notifications" data-user-id="<%= current_user.id %>">
+              <span class="tag is-danger is-small notification-counter"><%= current_user.notifications.unread.count %></span>
+              <span class="icon">
+                <i class="far fa-bell"></i>
+              </span>
+            </div>
+          <% else %>
+            <div>
+              <span class="tag is-primary is-small notification-counter">0</span>
+              <span class="icon">
+                <i class="far fa-bell"></i>
+              </span>
+            </div>
+          <% end %>
+        </div>
+
+        <div class="navbar-item">
           <div class="buttons">
           <% if user_signed_in? %>
             <button class="button is-primary is-inverted create-room-button">

--- a/app/views/layouts/_navbar.html.erb
+++ b/app/views/layouts/_navbar.html.erb
@@ -47,3 +47,5 @@
     </div>
   <% end %>
 </nav>
+
+<%= render 'shared/notifications' %>

--- a/app/views/layouts/_navbar.html.erb
+++ b/app/views/layouts/_navbar.html.erb
@@ -13,20 +13,25 @@
 
       <div class="navbar-end">
         <div class="navbar-item">
-          <% if has_unread_notifications?(current_user) %>
-            <div id="notifications" data-user-id="<%= current_user.id %>">
-              <span class="tag is-danger is-small notification-counter"><%= current_user.notifications.unread.count %></span>
-              <span class="icon">
-                <i class="far fa-bell"></i>
-              </span>
-            </div>
-          <% else %>
-            <div>
-              <span class="tag is-primary is-small notification-counter">0</span>
-              <span class="icon">
-                <i class="far fa-bell"></i>
-              </span>
-            </div>
+          <% if user_signed_in? %>
+            <% if has_unread_notifications?(current_user) %>
+              <div id="notifications" class="dropdown" aria-haspopup="true" aria-controls="dropdown-menu" data-user-id="<%= current_user.id %>">
+                <div class="dropdown-trigger">
+                  <span class="tag is-danger is-small notification-counter"><%= current_user.notifications.unread.count %></span>
+                  <span class="icon">
+                    <i class="far fa-bell"></i>
+                  </span>
+                </div>
+                <%= render 'shared/notifications' %>
+              </div>
+            <% else %>
+              <div>
+                <span class="tag is-primary is-small notification-counter">0</span>
+                <span class="icon">
+                  <i class="far fa-bell"></i>
+                </span>
+              </div>
+            <% end %>
           <% end %>
         </div>
 
@@ -66,4 +71,3 @@
   <% end %>
 </nav>
 
-<%= render 'shared/notifications' %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -10,6 +10,7 @@
     <%= stylesheet_pack_tag 'application' %>
     <%= javascript_pack_tag 'application' %>
     <%= javascript_pack_tag 'create_room_modal' %>
+    <%= javascript_pack_tag 'notification_feed' %>
   </head>
 
   <%= render "layouts/navbar" %>

--- a/app/views/shared/_notifications.html.erb
+++ b/app/views/shared/_notifications.html.erb
@@ -1,12 +1,12 @@
-<div class="notification-feed columns is-overlay is-hidden">
-  <div class="column is-4 is-offset-8">
-    <div class="box notifications-box" style="width: 300px;">
-      <% if has_unread_notifications?(current_user) %>
-        <% current_user.notifications.unread.each do |notification| %>
+<div class="notification-feed dropdown-menu" id="dropdown-menu">
+  <div class="dropdown-content">
+    <% if has_unread_notifications?(current_user) %>
+      <% current_user.notifications.unread.each do |notification| %>
+        <div class="dropdown-item">
           <%= "#{notification.actor.display_name} uploaded a jam to " %>
           <%= link_to notification.target.room.name, room_path(notification.target.room)%>
-        <% end %>
+        </div>
       <% end %>
-    </div>
+    <% end %>
   </div>
 </div>

--- a/app/views/shared/_notifications.html.erb
+++ b/app/views/shared/_notifications.html.erb
@@ -3,7 +3,7 @@
     <% if has_unread_notifications?(current_user) %>
       <% current_user.notifications.unread.each do |notification| %>
         <div class="dropdown-item">
-          <%= "#{notification.actor.display_name} uploaded a jam to " %>
+          <%= "#{notification.target.user.display_name} uploaded a jam to " %>
           <%= link_to notification.target.room.name, room_path(notification.target.room)%>
         </div>
       <% end %>

--- a/app/views/shared/_notifications.html.erb
+++ b/app/views/shared/_notifications.html.erb
@@ -1,15 +1,12 @@
-<div class="container">
-  <div class="notification-feed columns is-hidden is-mobile">
-    <div class="column is-4 is-offset-8">
-      <div class="box" style="width: 300px;">
-        <% if has_unread_notifications?(current_user) %>
-          <% current_user.notifications.unread.each do |notification| %>
-            <%= "#{notification.actor.display_name} uploaded a jam to " %>
-            <%= link_to notification.target.room.name, room_path(notification.target.room)%>
-          <% end %>
+<div class="notification-feed columns is-overlay is-hidden">
+  <div class="column is-4 is-offset-8">
+    <div class="box notifications-box" style="width: 300px;">
+      <% if has_unread_notifications?(current_user) %>
+        <% current_user.notifications.unread.each do |notification| %>
+          <%= "#{notification.actor.display_name} uploaded a jam to " %>
+          <%= link_to notification.target.room.name, room_path(notification.target.room)%>
         <% end %>
-      </div>
+      <% end %>
     </div>
   </div>
 </div>
-

--- a/app/views/shared/_notifications.html.erb
+++ b/app/views/shared/_notifications.html.erb
@@ -1,0 +1,3 @@
+<% current_user&.notifications&.each do |notification| %>
+  <%= "#{notification.actor.display_name} uploaded a jam to #{notification.target.room.name}" %>
+<% end %>

--- a/app/views/shared/_notifications.html.erb
+++ b/app/views/shared/_notifications.html.erb
@@ -1,3 +1,15 @@
-<% current_user&.notifications&.each do |notification| %>
-  <%= "#{notification.actor.display_name} uploaded a jam to #{notification.target.room.name}" %>
-<% end %>
+<div class="container">
+  <div class="notification-feed columns is-hidden is-mobile">
+    <div class="column is-4 is-offset-8">
+      <div class="box" style="width: 300px;">
+        <% if has_unread_notifications?(current_user) %>
+          <% current_user.notifications.unread.each do |notification| %>
+            <%= "#{notification.actor.display_name} uploaded a jam to " %>
+            <%= link_to notification.target.room.name, room_path(notification.target.room)%>
+          <% end %>
+        <% end %>
+      </div>
+    </div>
+  </div>
+</div>
+

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,7 +8,9 @@ Rails.application.routes.draw do
   devise_for :users
 
   resources :users do
-    resources :notifications, only: :index
+    resources :notifications, only: :index do
+      put "read", on: :collection
+    end
   end
 
   resources :rooms, only: %i[create show] do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,10 +1,15 @@
 # frozen_string_literal: true
 
 Rails.application.routes.draw do
-  devise_for :users
   root 'static#beta'
   post '/validate_beta_user', to: 'static#validate_beta_user'
   get 'home', to: 'static#index'
+
+  devise_for :users
+
+  resources :users do
+    resources :notifications, only: :index
+  end
 
   resources :rooms, only: %i[create show] do
     resources :jams, only: :create

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,8 +8,11 @@ Rails.application.routes.draw do
   devise_for :users
 
   resources :users do
-    resources :notifications, only: :index do
-      put "read", on: :collection
+    # # Default to json format for all notification routes
+    defaults format: :json do
+      resources :notifications, only: :index do
+        put "read", on: :collection
+      end
     end
   end
 

--- a/db/migrate/20200401235510_create_notifications.rb
+++ b/db/migrate/20200401235510_create_notifications.rb
@@ -1,0 +1,14 @@
+class CreateNotifications < ActiveRecord::Migration[6.0]
+  def change
+    create_table :notifications do |t|
+      t.references :user, null: false, foreign_key: true
+      t.integer :actor_id
+      t.string :notify_type, null: false
+      t.string :target_type
+      t.integer :target_id
+      t.datetime :read_at
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20200401235510_create_notifications.rb
+++ b/db/migrate/20200401235510_create_notifications.rb
@@ -2,10 +2,8 @@ class CreateNotifications < ActiveRecord::Migration[6.0]
   def change
     create_table :notifications do |t|
       t.references :user, null: false, foreign_key: true
-      t.integer :actor_id
-      t.string :notify_type, null: false
-      t.string :target_type
-      t.integer :target_id
+      t.string :event, null: false
+      t.references :target, polymorphic: true, null: false
       t.datetime :read_at
 
       t.timestamps

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -78,6 +78,18 @@ ActiveRecord::Schema.define(version: 2020_04_02_223118) do
     t.index ["user_id"], name: "index_jams_on_user_id"
   end
 
+  create_table "notifications", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.integer "actor_id"
+    t.string "notify_type", null: false
+    t.string "target_type"
+    t.integer "target_id"
+    t.datetime "read_at"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["user_id"], name: "index_notifications_on_user_id"
+  end
+
   create_table "rooms", force: :cascade do |t|
     t.string "name"
     t.citext "public_id", null: false
@@ -115,5 +127,6 @@ ActiveRecord::Schema.define(version: 2020_04_02_223118) do
   add_foreign_key "activities", "users"
   add_foreign_key "jams", "rooms"
   add_foreign_key "jams", "users"
+  add_foreign_key "notifications", "users"
   add_foreign_key "rooms", "users"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -80,13 +80,13 @@ ActiveRecord::Schema.define(version: 2020_04_02_223118) do
 
   create_table "notifications", force: :cascade do |t|
     t.bigint "user_id", null: false
-    t.integer "actor_id"
-    t.string "notify_type", null: false
-    t.string "target_type"
-    t.integer "target_id"
+    t.string "event", null: false
+    t.string "target_type", null: false
+    t.bigint "target_id", null: false
     t.datetime "read_at"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.index ["target_type", "target_id"], name: "index_notifications_on_target_type_and_target_id"
     t.index ["user_id"], name: "index_notifications_on_user_id"
   end
 

--- a/spec/factories/notifications.rb
+++ b/spec/factories/notifications.rb
@@ -1,10 +1,13 @@
 FactoryBot.define do
   factory :notification do
     user
-    association :actor, factory: :user
+
+    # Default to creating a jam
+    event { "jam_created" }
+    association :target, factory: :jam
 
     trait :jam do
-      notify_type { "jam_created" }
+      event { "jam_created" }
       association :target, factory: :jam
     end
   end

--- a/spec/factories/notifications.rb
+++ b/spec/factories/notifications.rb
@@ -1,0 +1,11 @@
+FactoryBot.define do
+  factory :notification do
+    user
+    association :actor, factory: :user
+
+    trait :jam do
+      notify_type { "jam_created" }
+      association :target, factory: :jam
+    end
+  end
+end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -21,30 +21,17 @@ RSpec.describe ApplicationHelper, :type => :helper do
   end
 
   describe "#has_unread_notifications?" do
-    let(:notification) { create(:notification, :jam) }
-
-    context 'unread notifications' do
-      let(:user) { notification.user }
-
-      it 'returns true' do
-        expect(helper.has_unread_notifications?(user)).to be true
-      end
+    example 'unread notifications' do
+       notification = create(:notification)
+       expect(helper.has_unread_notifications?(notification.user)).to be true
     end
 
-    context 'no unread notifications' do
-      let(:user) { create(:user) }
-
-      it 'returns false' do
-        expect(helper.has_unread_notifications?(user)).to be false
-      end
+    example 'no unread notifications' do
+       expect(helper.has_unread_notifications?(create(:user))).to be false
     end
 
-    context 'user is not logged in' do
-      let(:user) { nil }
-
-      it 'returns false' do
-        expect(helper.has_unread_notifications?(user)).to be false
-      end
+    example 'user is not logged in' do
+      expect(helper.has_unread_notifications?(nil)).to be false
     end
   end
 end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -19,4 +19,32 @@ RSpec.describe ApplicationHelper, :type => :helper do
       expect(helper.beta_user?).to be false
     end
   end
+
+  describe "#has_unread_notifications?" do
+    let(:notification) { create(:notification, :jam) }
+
+    context 'unread notifications' do
+      let(:user) { notification.user }
+
+      it 'returns true' do
+        expect(helper.has_unread_notifications?(user)).to be true
+      end
+    end
+
+    context 'no unread notifications' do
+      let(:user) { create(:user) }
+
+      it 'returns false' do
+        expect(helper.has_unread_notifications?(user)).to be false
+      end
+    end
+
+    context 'user is not logged in' do
+      let(:user) { nil }
+
+      it 'returns false' do
+        expect(helper.has_unread_notifications?(user)).to be false
+      end
+    end
+  end
 end

--- a/spec/models/jam_spec.rb
+++ b/spec/models/jam_spec.rb
@@ -1,10 +1,9 @@
 require 'rails_helper'
 
 RSpec.describe Jam, type: :model do
+  let(:jam) { build(:jam) }
 
   describe 'Validations' do
-    let(:jam) { build(:jam) }
-
     it 'is valid out of the factory' do
       expect(jam).to be_valid
     end
@@ -20,5 +19,12 @@ RSpec.describe Jam, type: :model do
       expect(jam).to_not be_valid
       expect(jam.errors[:file]).to include("must be an audio file")
     end
+  end
+
+  it 'creates an activity' do
+    jam = build(:jam, room: create(:room))
+    expect do
+      jam.save
+    end.to change(Activity, :count).by(1)
   end
 end

--- a/spec/models/notification_spec.rb
+++ b/spec/models/notification_spec.rb
@@ -1,0 +1,11 @@
+require 'rails_helper'
+
+RSpec.describe Notification, type: :model do
+  describe 'Validations' do
+    let(:notification) { build(:notification, :jam) }
+
+    it 'is valid out of the factory' do
+      expect(notification).to be_valid
+    end
+  end
+end

--- a/spec/models/notification_spec.rb
+++ b/spec/models/notification_spec.rb
@@ -2,10 +2,17 @@ require 'rails_helper'
 
 RSpec.describe Notification, type: :model do
   describe 'Validations' do
-    let(:notification) { build(:notification, :jam) }
+    let(:notification) { build(:notification) }
 
     it 'is valid out of the factory' do
       expect(notification).to be_valid
+    end
+  end
+
+  describe ".unread" do
+    it 'returns a Notification that is unread' do
+      create(:notification)
+      expect(Notification.unread.take.read_at).to  be nil
     end
   end
 end

--- a/spec/models/room_spec.rb
+++ b/spec/models/room_spec.rb
@@ -22,6 +22,12 @@ RSpec.describe Room, type: :model do
     expect(room.public_id).to match(/[0-9a-f]{32}/)
   end
 
+  it 'creates an activity' do
+    expect do
+      create(:room)
+    end.to change(Activity, :count).by(1)
+  end
+
   describe ".recommended" do
     it 'returns a Room that contains a jam' do
       create(:jam, room: room)

--- a/spec/models/room_spec.rb
+++ b/spec/models/room_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe Room, type: :model do
     expect(room.public_id).to match(/[0-9a-f]{32}/)
   end
 
-  describe "Room#recommended" do
+  describe ".recommended" do
     it 'returns a Room that contains a jam' do
       create(:jam, room: room)
       expect(Room.recommended.take).to be_an_instance_of(Room)
@@ -41,6 +41,17 @@ RSpec.describe Room, type: :model do
   describe '#to_param' do
     it 'returns the room hash' do
       expect(room.to_param).to eq room.public_id
+    end
+  end
+
+  describe '#users' do
+    let(:uploader) { create(:user) }
+
+    it 'returns all participants in the room' do
+      create(:jam, room: room, user: room.user)
+      create(:jam, room: room, user: uploader)
+
+      expect(room.users).to match([room.user, uploader])
     end
   end
 end

--- a/spec/requests/controllers/jams_controller_spec.rb
+++ b/spec/requests/controllers/jams_controller_spec.rb
@@ -48,6 +48,20 @@ RSpec.describe JamsController, type: :request do
       expect(uploaded_jam.activities.first.user).to eq user
     end
 
+    it 'creates a notification' do
+      create(:jam, room: room, user: create(:user))
+
+      expect do
+        action
+      end.to change(Notification, :count).from(0).to(1)
+    end
+
+    it 'does not create a notification for the current user' do
+      expect do
+        action
+      end.to_not change{ user.notifications.count }
+    end
+
     context "with an invalid file" do
       let(:file) { fixture_file_upload('spec/support/assets/invalid_file.txt') }
 

--- a/spec/requests/controllers/jams_controller_spec.rb
+++ b/spec/requests/controllers/jams_controller_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe JamsController, type: :request do
     post '/validate_beta_user', params: { beta_code: 'correct-code' }
   end
 
-  let(:room) { create(:room) }
+  let!(:room) { create(:room) }
 
   describe 'POST #create' do
     it_behaves_like 'Auth Required'
@@ -40,7 +40,7 @@ RSpec.describe JamsController, type: :request do
     it 'creates an activity' do
       expect do
         action
-      end.to change(Activity, :count).from(0).to(1)
+      end.to change(Activity, :count).by(1)
     end
 
     it 'associates the activity with the current user' do

--- a/spec/requests/controllers/jams_controller_spec.rb
+++ b/spec/requests/controllers/jams_controller_spec.rb
@@ -37,13 +37,7 @@ RSpec.describe JamsController, type: :request do
       expect(response.body).to include('Jam successfully created!')
     end
 
-    it 'creates an activity' do
-      expect do
-        action
-      end.to change(Activity, :count).by(1)
-    end
-
-    it 'associates the activity with the current user' do
+    it 'associates generated activity with the current user' do
       action
       expect(uploaded_jam.activities.first.user).to eq user
     end

--- a/spec/requests/controllers/notifications_controller_spec.rb
+++ b/spec/requests/controllers/notifications_controller_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe NotificationsController, type: :request do
       end
 
       it 'returns non-empty array as json' do
-        create(:notification, :jam, user: user)
+        create(:notification, user: user)
 
         action
 
@@ -52,7 +52,7 @@ RSpec.describe NotificationsController, type: :request do
       end
 
       it 'marks an unread notification read' do
-        create(:notification, :jam, user: user)
+        create(:notification, user: user)
 
         expect do
           action

--- a/spec/requests/controllers/notifications_controller_spec.rb
+++ b/spec/requests/controllers/notifications_controller_spec.rb
@@ -31,4 +31,33 @@ RSpec.describe NotificationsController, type: :request do
       end
     end
   end
+
+  describe 'PUT #read' do
+    it_behaves_like 'Auth Required'
+
+    let(:user) { create(:user) }
+    before { sign_in(user) }
+
+    let(:action) { put read_user_notifications_path(user) }
+
+    context 'json' do
+      let(:action) do
+        headers = { 'Accept': 'application/json'}
+        put read_user_notifications_path(user), headers: headers
+      end
+
+      it 'is successful' do
+        action
+        expect(response).to be_successful
+      end
+
+      it 'marks an unread notification read' do
+        create(:notification, :jam, user: user)
+
+        expect do
+          action
+        end.to change{ user.notifications.unread.count }.from(1).to(0)
+      end
+    end
+  end
 end

--- a/spec/requests/controllers/notifications_controller_spec.rb
+++ b/spec/requests/controllers/notifications_controller_spec.rb
@@ -1,0 +1,34 @@
+require 'rails_helper'
+
+RSpec.describe NotificationsController, type: :request do
+  # TODO: Remove when beta invite requirements are removed
+  before do
+    InviteCode.create(code: 'correct-code')
+    post '/validate_beta_user', params: { beta_code: 'correct-code' }
+  end
+
+  describe 'GET #index' do
+    it_behaves_like 'Auth Required'
+    let(:user) { create(:user) }
+    before { sign_in(user) }
+
+    let(:action) { get user_notifications_path(user) }
+
+    context 'json request' do
+      let(:action) do
+        headers = { 'Accept': 'application/json'}
+        get user_notifications_path(user), headers: headers
+      end
+
+      it 'returns non-empty array as json' do
+        create(:notification, :jam, user: user)
+
+        action
+
+        expect(response).to be_successful
+        expect(response.content_type).to eq("application/json; charset=utf-8")
+        expect(JSON.parse(response.body)).to_not be_empty
+      end
+    end
+  end
+end

--- a/spec/requests/notifications_request_spec.rb
+++ b/spec/requests/notifications_request_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe 'Notifications', type: :request do
 
   let(:user) { create(:user) }
   let(:uploader) { create(:user, display_name: 'uploader') }
-  let(:room) { create(:room, name: 'notification-room') }
+  let(:room) { create(:room, name: 'notification-room', public_id: 'notification-room') }
   let(:jam) { create(:jam, room: room) }
 
   before { sign_in user }
@@ -19,6 +19,6 @@ RSpec.describe 'Notifications', type: :request do
   it 'shows unread notifications in the navbar' do
     create(:notification, :jam, target: jam, user: user, actor: uploader)
     get home_path
-    expect(response.body).to include('uploader uploaded a jam to notification-room')
+    expect(response.body).to include("uploader uploaded a jam")
   end
 end

--- a/spec/requests/notifications_request_spec.rb
+++ b/spec/requests/notifications_request_spec.rb
@@ -12,12 +12,12 @@ RSpec.describe 'Notifications', type: :request do
   let(:user) { create(:user) }
   let(:uploader) { create(:user, display_name: 'uploader') }
   let(:room) { create(:room, name: 'notification-room', public_id: 'notification-room') }
-  let(:jam) { create(:jam, room: room) }
+  let(:jam) { create(:jam, room: room, user: uploader) }
 
   before { sign_in user }
 
   it 'shows unread notifications in the navbar' do
-    create(:notification, :jam, target: jam, user: user, actor: uploader)
+    create(:notification, target: jam, user: user)
     get home_path
     expect(response.body).to include("uploader uploaded a jam")
   end

--- a/spec/requests/notifications_request_spec.rb
+++ b/spec/requests/notifications_request_spec.rb
@@ -9,36 +9,16 @@ RSpec.describe 'Notifications', type: :request do
     post '/validate_beta_user', params: { beta_code: 'correct-code' }
   end
 
-  let(:file) { fixture_file_upload('spec/support/assets/test.mp3') }
-  let(:jam_params) { { bpm: '100', file: file } }
-  let(:upload_jam) { post room_jams_path(room), params: { jam: jam_params } }
-
   let(:user) { create(:user) }
-  let(:room) { create(:room, user: user, name: 'notification-room') }
   let(:uploader) { create(:user, display_name: 'uploader') }
+  let(:room) { create(:room, name: 'notification-room') }
+  let(:jam) { create(:jam, room: room) }
 
-  context 'room owner' do
-    before do
-      sign_in uploader
-    end
+  before { sign_in user }
 
-    it 'creates an unread notification' do
-      expect do
-        upload_jam
-      end.to change{ user.notifications.unread.count }
-    end
-
-    it 'shows unread notifications in the navbar' do
-      upload_jam
-      sign_in user
-      get home_path
-      expect(response.body).to include('uploader uploaded a jam to notification-room')
-    end
-  end
-
-  context 'room contributor' do
-    it 'creates an unread notification' do
-
-    end
+  it 'shows unread notifications in the navbar' do
+    create(:notification, :jam, target: jam, user: user, actor: uploader)
+    get home_path
+    expect(response.body).to include('uploader uploaded a jam to notification-room')
   end
 end

--- a/spec/requests/notifications_request_spec.rb
+++ b/spec/requests/notifications_request_spec.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Notifications', type: :request do
+  # TODO: Remove when beta invite requirements are removed
+  before(:each) do
+    InviteCode.create(code: 'correct-code')
+    post '/validate_beta_user', params: { beta_code: 'correct-code' }
+  end
+
+  let(:file) { fixture_file_upload('spec/support/assets/test.mp3') }
+  let(:jam_params) { { bpm: '100', file: file } }
+  let(:upload_jam) { post room_jams_path(room), params: { jam: jam_params } }
+
+  let(:user) { create(:user) }
+  let(:room) { create(:room, user: user, name: 'notification-room') }
+  let(:uploader) { create(:user, display_name: 'uploader') }
+
+  context 'room owner' do
+    before do
+      sign_in uploader
+    end
+
+    it 'creates an unread notification' do
+      expect do
+        upload_jam
+      end.to change{ user.notifications.unread.count }
+    end
+
+    it 'shows unread notifications in the navbar' do
+      upload_jam
+      sign_in user
+      get home_path
+      expect(response.body).to include('uploader uploaded a jam to notification-room')
+    end
+  end
+
+  context 'room contributor' do
+    it 'creates an unread notification' do
+
+    end
+  end
+end

--- a/spec/services/notification_service_spec.rb
+++ b/spec/services/notification_service_spec.rb
@@ -1,0 +1,14 @@
+require "rails_helper"
+
+RSpec.describe NotificationService do
+  describe '.notify' do
+    let(:jam) { create(:jam) }
+    let(:user) { create(:user) }
+
+    it 'creates a notification' do
+      expect do
+        NotificationService.notify(subject: jam, user: user, event: :jam_created)
+      end.to change(Notification, :count).by(1)
+    end
+  end
+end

--- a/spec/support/shared_examples/auth_required_shared_example.rb
+++ b/spec/support/shared_examples/auth_required_shared_example.rb
@@ -1,6 +1,7 @@
 RSpec.shared_examples "Auth Required" do
   it "requires authentication" do
     sign_out :user
-    expect(action).to redirect_to(new_user_session_path)
+    action
+    expect(response).to redirect_to(new_user_session_path).or have_http_status(401)
   end
 end


### PR DESCRIPTION
This PR adds a NotificationService which is used to create Notifications when a user uploads a Jam to a room. Notifications are created for all users who are not the uploaders and that have uploaded a track to the room at some point.

#### With a notification:
![with-notifications](https://user-images.githubusercontent.com/723637/78300396-0ce36b00-74fd-11ea-9127-5976ebd7bb84.png)

#### Menu
![Screen Shot 2020-04-03 at 10 18 06 AM](https://user-images.githubusercontent.com/723637/78376869-85e1d180-7594-11ea-8993-ff02f8ad3910.png)

#### Without a notification:
![without-notificaitons](https://user-images.githubusercontent.com/723637/78300388-0a811100-74fd-11ea-8e78-fb466fc66f1e.png)