### PR TITLE
Improve activity feed

### DIFF
--- a/app/controllers/static_controller.rb
+++ b/app/controllers/static_controller.rb
@@ -5,7 +5,7 @@ class StaticController < ApplicationController
   skip_before_action :authenticate_user!
 
   def index
-    @activities = current_user&.activities
+    @has_activities = current_user&.activities&.exists?
   end
 
   def beta

--- a/app/controllers/static_controller.rb
+++ b/app/controllers/static_controller.rb
@@ -6,6 +6,7 @@ class StaticController < ApplicationController
 
   def index
     @has_activities = current_user&.activities&.exists?
+    @random_room = Room.recommended.take
   end
 
   def beta

--- a/app/presenters/activity_presenter.rb
+++ b/app/presenters/activity_presenter.rb
@@ -1,6 +1,5 @@
 class ActivityPresenter < SimpleDelegator
   include ActionView::Helpers::SanitizeHelper
-  include ActionView::Helpers::DateHelper
 
   def self.activities(owner, view)
     owner.activities.order(created_at: :desc).map { |activity| new(activity, view) }
@@ -29,7 +28,7 @@ class ActivityPresenter < SimpleDelegator
   private
 
   def time
-    "#{time_ago_in_words(subject.created_at)} ago"
+    "#{@view.time_ago_in_words(subject.created_at)} ago"
   end
 
   def sanitized_filename

--- a/app/presenters/activity_presenter.rb
+++ b/app/presenters/activity_presenter.rb
@@ -2,7 +2,7 @@ class ActivityPresenter < SimpleDelegator
   include ActionView::Helpers::SanitizeHelper
 
   def self.activities(owner, view)
-    owner.activities.map { |activity| new(activity, view) }
+    owner.activities.order(created_at: :desc).map { |activity| new(activity, view) }
   end
 
   def initialize(activity, view)

--- a/app/presenters/activity_presenter.rb
+++ b/app/presenters/activity_presenter.rb
@@ -1,5 +1,6 @@
 class ActivityPresenter < SimpleDelegator
   include ActionView::Helpers::SanitizeHelper
+  include ActionView::Helpers::DateHelper
 
   def self.activities(owner, view)
     owner.activities.order(created_at: :desc).map { |activity| new(activity, view) }
@@ -14,9 +15,10 @@ class ActivityPresenter < SimpleDelegator
   def message
     case subject_type
     when "Jam"
-      "You uploaded #{jam_icon} #{sanitized_filename} to #{room_icon} #{room_link_for(subject.room)}".html_safe
+      "You uploaded #{jam_icon} #{sanitized_filename} " \
+      "to #{room_icon} #{room_link_for(subject.room)} #{time}".html_safe
     when "Room"
-      "You created #{room_icon} #{room_link_for(subject)}".html_safe
+      "You created #{room_icon} #{room_link_for(subject)} #{time}".html_safe
     end
   end
 
@@ -25,6 +27,10 @@ class ActivityPresenter < SimpleDelegator
   end
 
   private
+
+  def time
+    "#{time_ago_in_words(subject.created_at)} ago"
+  end
 
   def sanitized_filename
     sanitize(subject&.file&.filename.to_s)

--- a/app/views/static/index.html.erb
+++ b/app/views/static/index.html.erb
@@ -9,8 +9,8 @@
           Join a room to start building up a track or start your own.
         </h2>
 
-        <% if(room = Room.recommended.take) %>
-          <%= link_to(room_path(room), class: "button is-primary is-inverted") do %>
+        <% if(@random_room) %>
+          <%= link_to(room_path(@random_room), class: "button is-primary is-inverted") do %>
             <span class="icon">
               <i class="fas fa-door-open"></i>
             </span>

--- a/app/views/static/index.html.erb
+++ b/app/views/static/index.html.erb
@@ -26,7 +26,7 @@
         </button>
       </section>
 
-      <% if @current_user&.activities&.any? %>
+      <% if @has_activities %>
         <section class="section">
           <%= render "shared/activity_feed", owner: @current_user %>
         </section>

--- a/spec/presenters/activity_presenter_spec.rb
+++ b/spec/presenters/activity_presenter_spec.rb
@@ -8,30 +8,37 @@ describe ActivityPresenter do
 
   context 'presenting a jam' do
     let(:jam) { build(:jam, room: room) }
-    let(:activity) { create(:activity, :room, subject: jam) }
+    let!(:activity) { create(:activity, :room, subject: jam) }
 
     it 'returns correct type' do
       expect(presenter.type).to eq('jam')
     end
 
     it 'returns a message' do
-      expect(presenter.message).to eq(
-        "You uploaded <i class=\"fas fa-music\"></i> test.mp3 to <i class=\"fas fa-door-open\"></i> <a href=\"/rooms/activity-presenter-room\">activity-presenter-room</a>"
-      )
+      travel 10.minutes do
+        expect(presenter.message).to eq(
+          "You uploaded <i class=\"fas fa-music\"></i> test.mp3 " \
+          "to <i class=\"fas fa-door-open\"></i> <a href=\"/rooms/activity-presenter-room\">activity-presenter-room</a> " \
+          "10 minutes ago"
+        )
+      end
     end
   end
 
   context 'presenting a room' do
-    let(:activity) { create(:activity, :room, subject: room) }
+    let!(:activity) { create(:activity, :room, subject: room, created_at: 10.minutes.ago) }
 
     it 'returns correct type' do
       expect(presenter.type).to eq('room')
     end
 
     it 'returns a message' do
-      expect(presenter.message).to eq(
-        "You created <i class=\"fas fa-door-open\"></i> <a href=\"/rooms/activity-presenter-room\">activity-presenter-room</a>"
-      )
+      travel 10.minutes do
+        expect(presenter.message).to eq(
+          "You created <i class=\"fas fa-door-open\"></i> <a href=\"/rooms/activity-presenter-room\">activity-presenter-room</a> " \
+          "10 minutes ago"
+        )
+      end
     end
   end
 end


### PR DESCRIPTION
https://github.com/tomekr/jamroulette/commit/03de95088a9fa19e75e98c9831abc65cb7864ff1 sorts the order of activities in descending order, showing the most recent activity at the top of the feed.

https://github.com/tomekr/jamroulette/commit/01df8482afc350bbe9ea4a0ba1cc78a633d47cd9 adds a timestamp to the end of the activity message. (e.g. "You uploaded test.mp3 to jams about 1 hour ago")