### PR TITLE
Use Room names in Activity feed

### DIFF
--- a/app/presenters/activity_presenter.rb
+++ b/app/presenters/activity_presenter.rb
@@ -36,7 +36,7 @@ class ActivityPresenter < SimpleDelegator
   end
 
   def room_link_for(room)
-    @view.link_to room.public_id, @view.room_path(room)
+    @view.link_to room.name, @view.room_path(room)
   end
 
   def room_icon

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -26,21 +26,17 @@ alice = User.create(
 
 # Create an empty room
 empty_room = Room.create!(public_id: 'empty', user: bob, name: 'Empty Room')
-empty_room.activities.create!(user: bob)
 
 # Create a room with two attached jams
 room = Room.create!(public_id: 'jams', user: bob, name: 'Jam Room')
-room.activities.create!(user: bob)
 
 jam = room.jams.build(bpm: '120', user: bob)
 jam.file.attach(io: File.open('spec/support/assets/test.mp3'), filename: 'test.mp3', content_type: 'audio/mpeg')
 jam.save
-jam.activities.create(user: jam.user)
 
 other_jam = room.jams.build(bpm: '120', user: alice)
 other_jam.file.attach(io: File.open('spec/support/assets/test.mp3'), filename: 'test.mp3', content_type: 'audio/mpeg')
 other_jam.save
-other_jam.activities.create(user: other_jam.user)
 
 # TODO Remove when no longer in beta
 InviteCode.create(code: 'Mellon')

--- a/spec/presenters/activity_presenter_spec.rb
+++ b/spec/presenters/activity_presenter_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 describe ActivityPresenter do
   include ActionView::TestCase::Behavior
 
-  let(:room) { build(:room, public_id: 'activity-presenter-room') }
+  let(:room) { build(:room, public_id: 'activity-presenter-room', name: 'Presenter Room') }
   let(:presenter) { ActivityPresenter.new(activity, view) }
 
   context 'presenting a jam' do
@@ -18,7 +18,7 @@ describe ActivityPresenter do
       travel 10.minutes do
         expect(presenter.message).to eq(
           "You uploaded <i class=\"fas fa-music\"></i> test.mp3 " \
-          "to <i class=\"fas fa-door-open\"></i> <a href=\"/rooms/activity-presenter-room\">activity-presenter-room</a> " \
+          "to <i class=\"fas fa-door-open\"></i> <a href=\"/rooms/activity-presenter-room\">Presenter Room</a> " \
           "10 minutes ago"
         )
       end
@@ -35,7 +35,7 @@ describe ActivityPresenter do
     it 'returns a message' do
       travel 10.minutes do
         expect(presenter.message).to eq(
-          "You created <i class=\"fas fa-door-open\"></i> <a href=\"/rooms/activity-presenter-room\">activity-presenter-room</a> " \
+          "You created <i class=\"fas fa-door-open\"></i> <a href=\"/rooms/activity-presenter-room\">Presenter Room</a> " \
           "10 minutes ago"
         )
       end

--- a/spec/system/home_page_spec.rb
+++ b/spec/system/home_page_spec.rb
@@ -89,7 +89,7 @@ RSpec.describe 'visiting the home page', type: :system do
           visit home_path
 
           expect(page).to have_content("Activity Feed")
-          expect(page).to have_content("You uploaded #{jam.file.filename} to #{room.public_id}")
+          expect(page).to have_content("You uploaded #{jam.file.filename} to #{room.name}")
         end
       end
     end


### PR DESCRIPTION
This PR switches from using Room public_id's to using a Room's name.

#### Before
![before](https://user-images.githubusercontent.com/723637/78413888-1ba24e80-75df-11ea-80ee-1d383859e07e.png)

#### After
![after](https://user-images.githubusercontent.com/723637/78413889-1e04a880-75df-11ea-9fe4-8cab61beec33.png)
