### PR TITLE
Use acts_as_taggable_on to store jam attributes as tags

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,6 +24,8 @@ gem 'delayed_job_active_record'
 
 gem 'devise', '4.7.1'
 
+gem 'acts-as-taggable-on', '~> 6.0'
+
 # Use Active Storage variant
 # gem 'image_processing', '~> 1.2'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -56,6 +56,8 @@ GEM
       minitest (~> 5.1)
       tzinfo (~> 1.1)
       zeitwerk (~> 2.2)
+    acts-as-taggable-on (6.5.0)
+      activerecord (>= 5.0, < 6.1)
     addressable (2.7.0)
       public_suffix (>= 2.0.2, < 5.0)
     ast (2.4.0)
@@ -295,6 +297,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  acts-as-taggable-on (~> 6.0)
   aws-sdk-s3 (= 1.61.1)
   bootsnap (>= 1.4.2)
   byebug

--- a/app/controllers/jams_controller.rb
+++ b/app/controllers/jams_controller.rb
@@ -4,11 +4,12 @@ class JamsController < ApplicationController
   # POST /rooms/:public_id/jams
   def create
     room = Room.find_by!(public_id: params[:room_id])
-    jam = room.jams.build(file: jam_params[:file], bpm: jam_params[:bpm])
+    jam = room.jams.build(file: jam_params[:file])
 
     # Set Jam tags
-    # jam.bpm_list = jam_params[:bpm_list]
-    jam.song_key_list = jam_params[:song_key_list]
+    jam.bpm_list = jam_params[:bpm]
+    jam.song_key_list = jam_params[:song_key]
+    jam.jam_type_list = jam_params[:jam_type]
     jam.style_list = jam_params[:style_list]
     jam.could_use_list = jam_params[:could_use_list]
 
@@ -26,6 +27,6 @@ class JamsController < ApplicationController
   private
 
   def jam_params
-    params.require(:jam).permit(:file, :bpm, :song_key_list, :style_list, :could_use_list)
+    params.require(:jam).permit(:file, :bpm, :song_key, :jam_type, :style_list, :could_use_list)
   end
 end

--- a/app/controllers/jams_controller.rb
+++ b/app/controllers/jams_controller.rb
@@ -4,14 +4,7 @@ class JamsController < ApplicationController
   # POST /rooms/:public_id/jams
   def create
     room = Room.find_by!(public_id: params[:room_id])
-    jam = room.jams.build(file: jam_params[:file])
-
-    # Set Jam tags
-    jam.bpm_list = jam_params[:bpm]
-    jam.song_key_list = jam_params[:song_key]
-    jam.jam_type_list = jam_params[:jam_type]
-    jam.style_list = jam_params[:style_list]
-    jam.could_use_list = jam_params[:could_use_list]
+    jam = room.jams.build(jam_params)
 
     jam.user = current_user
 
@@ -27,6 +20,9 @@ class JamsController < ApplicationController
   private
 
   def jam_params
-    params.require(:jam).permit(:file, :bpm, :song_key, :jam_type, :style_list, :could_use_list)
+    params.require(:jam).permit(
+      :file, :bpm_list, :song_key_list,
+      :jam_type_list, :style_list, :could_use_list
+    )
   end
 end

--- a/app/controllers/jams_controller.rb
+++ b/app/controllers/jams_controller.rb
@@ -4,7 +4,13 @@ class JamsController < ApplicationController
   # POST /rooms/:public_id/jams
   def create
     room = Room.find_by!(public_id: params[:room_id])
-    jam = room.jams.build(jam_params)
+    jam = room.jams.build(file: jam_params[:file], bpm: jam_params[:bpm])
+
+    # Set Jam tags
+    # jam.bpm_list = jam_params[:bpm_list]
+    jam.song_key_list = jam_params[:song_key_list]
+    jam.style_list = jam_params[:style_list]
+    jam.could_use_list = jam_params[:could_use_list]
 
     jam.user = current_user
 
@@ -20,6 +26,6 @@ class JamsController < ApplicationController
   private
 
   def jam_params
-    params.require(:jam).permit(:bpm, :file)
+    params.require(:jam).permit(:file, :bpm, :song_key_list, :style_list, :could_use_list)
   end
 end

--- a/app/models/jam.rb
+++ b/app/models/jam.rb
@@ -2,6 +2,7 @@
 
 class Jam < ApplicationRecord
   include Trackable
+  acts_as_taggable_on :song_key, :styles, :could_use
 
   belongs_to :room
   belongs_to :user

--- a/app/models/jam.rb
+++ b/app/models/jam.rb
@@ -2,18 +2,39 @@
 
 class Jam < ApplicationRecord
   include Trackable
-  acts_as_taggable_on :song_key, :styles, :could_use
+  acts_as_taggable_on :bpm, :song_key, :jam_type, :styles, :could_use
 
   belongs_to :room
   belongs_to :user
   has_one_attached :file
   validates :file, presence: { message: "must be attached" }
   validate :content_type_is_audio
+  validate :jam_type_supported
 
   has_many :activities, as: :subject, dependent: :destroy
   has_many :notifications, as: :target, dependent: :destroy
 
+  def bpm
+    bpm_list.first
+  end
+
+  def song_key
+    song_key_list.first
+  end
+
+  def jam_type
+    jam_type_list.first
+  end
+
   private
+
+  def jam_type_supported
+    return unless jam_type
+
+    unless  ['MIX', 'SOLO'].include?(jam_type)
+      errors.add(:jam_type, "must be MIX or SOLO")
+    end
+  end
 
   def content_type_is_audio
     return unless file.attached?

--- a/app/views/rooms/_upload_track_modal.html.erb
+++ b/app/views/rooms/_upload_track_modal.html.erb
@@ -34,11 +34,11 @@
             <div class="field is-narrow">
               <div class="control">
                 <label class="radio">
-                  <%= form.radio_button :jam_type, "MIX", checked: true %>
+                  <%= form.radio_button :jam_type_list, "MIX", checked: true %>
                   MIX
                 </label>
                 <label class="radio">
-                  <%= form.radio_button :jam_type, "SOLO" %>
+                  <%= form.radio_button :jam_type_list, "SOLO" %>
                   SOLO
                 </label>
               </div>
@@ -50,7 +50,7 @@
           <label class="label">BPM</label>
           <div class="field has-addons">
             <div class="control">
-              <%= form.text_field :bpm, class: "input" %>
+              <%= form.text_field :bpm_list, class: "input" %>
             </div>
             <div class="control">
               <a class="button is-static">
@@ -62,7 +62,7 @@
 
         <div class="field">
           <label class="label">Song Key</label>
-          <%= form.text_field :song_key, class: "input", placeholder: '(e.g. "A Major", "G Dorian")' %>
+          <%= form.text_field :song_key_list, class: "input", placeholder: '(e.g. "A Major", "G Dorian")' %>
         </div>
 
         <div class="field">

--- a/app/views/rooms/_upload_track_modal.html.erb
+++ b/app/views/rooms/_upload_track_modal.html.erb
@@ -26,6 +26,26 @@
           </div>
         </div>
 
+        <h1 class="subtitle is-3">Supply Optional Info</h1>
+
+        <div class="field">
+          <label class="label">Jam Type</label>
+          <div class="field-body">
+            <div class="field is-narrow">
+              <div class="control">
+                <label class="radio">
+                  <%= form.radio_button :jam_type, "MIX", checked: true %>
+                  MIX
+                </label>
+                <label class="radio">
+                  <%= form.radio_button :jam_type, "SOLO" %>
+                  SOLO
+                </label>
+              </div>
+            </div>
+          </div>
+        </div>
+
         <div class="field">
           <label class="label">BPM</label>
           <div class="field has-addons">
@@ -42,13 +62,7 @@
 
         <div class="field">
           <label class="label">Song Key</label>
-          <%= form.text_field :song_key_list, class: "input", placeholder: '(e.g. "A Major", "G Dorian")' %>
-        </div>
-
-        <div class="field">
-          <label class="label">Styles</label>
-          <%= form.text_field :style_list, class: "input", placeholder: '(e.g. "Electronic, Lofi")' %>
-          <p class="help">Supports comma separated list</p>
+          <%= form.text_field :song_key, class: "input", placeholder: '(e.g. "A Major", "G Dorian")' %>
         </div>
 
         <div class="field">
@@ -57,7 +71,13 @@
           <p class="help">Supports comma separated list</p>
         </div>
 
+        <div class="field">
+          <label class="label">Styles</label>
+          <%= form.text_field :style_list, class: "input", placeholder: '(e.g. "Electronic, Lofi")' %>
+          <p class="help">Supports comma separated list</p>
+        </div>
       </section>
+
       <footer class="modal-card-foot">
         <%= submit_tag "Upload", class: "button is-success" %>
         <button class="button modal-close-button">Cancel</button>

--- a/app/views/rooms/_upload_track_modal.html.erb
+++ b/app/views/rooms/_upload_track_modal.html.erb
@@ -1,0 +1,68 @@
+<div id="upload-track-modal" class="modal">
+  <div class="modal-background"></div>
+  <div class="modal-card">
+    <%= form_with(model: @new_jam, url: [@room, @new_jam],  multipart: true,  local: true) do |form| %>
+      <header class="modal-card-head">
+        <p class="modal-card-title">Upload a Jam</p>
+        <button class="delete modal-close-button" aria-label="close"></button>
+      </header>
+      <section class="modal-card-body">
+        <div class="field">
+          <div id="file-upload-field" class="file has-name">
+            <label class="file-label">
+              <%= form.file_field :file, class: "file-input", accept: "audio/*" %>
+              <span class="file-cta">
+                <span class="file-icon">
+                  <i class="fas fa-upload"></i>
+                </span>
+                <span class="file-label">
+                  Choose a file...
+                </span>
+              </span>
+              <span class="file-name">
+                No file selected
+              </span>
+            </label>
+          </div>
+        </div>
+
+        <div class="field">
+          <label class="label">BPM</label>
+          <div class="field has-addons">
+            <div class="control">
+              <%= form.text_field :bpm, class: "input" %>
+            </div>
+            <div class="control">
+              <a class="button is-static">
+                bpm
+              </a>
+            </div>
+          </div>
+        </div>
+
+        <div class="field">
+          <label class="label">Song Key</label>
+          <%= form.text_field :song_key_list, class: "input", placeholder: '(e.g. "A Major", "G Dorian")' %>
+        </div>
+
+        <div class="field">
+          <label class="label">Styles</label>
+          <%= form.text_field :style_list, class: "input", placeholder: '(e.g. "Electronic, Lofi")' %>
+          <p class="help">Supports comma separated list</p>
+        </div>
+
+        <div class="field">
+          <label class="label">Which parts could this Jam use?</label>
+          <%= form.text_field :could_use_list, class: "input", placeholder: '(e.g. "Bass, Drums, Vocals")' %>
+          <p class="help">Supports comma separated list</p>
+        </div>
+
+      </section>
+      <footer class="modal-card-foot">
+        <%= submit_tag "Upload", class: "button is-success" %>
+        <button class="button modal-close-button">Cancel</button>
+      </footer>
+    <% end %>
+  </div>
+</div>
+

--- a/app/views/rooms/show.html.erb
+++ b/app/views/rooms/show.html.erb
@@ -26,6 +26,12 @@
             </span>
           </li>
           <li>
+            <span class="jam-attribute jam-attribute-bpm">
+              <span class="jam-key"><i class="fas fa-file-audio"></i> Jam Type: </span>
+              <span class="jam-value"><%= @current_jam.jam_type %></span>
+            </span>
+          </li>
+          <li>
             <span class="jam-attribute jam-attribute-length">
               <span class="jam-key"><i class="far fa-clock"></i> Length: </span>
               <span class="jam-value"><%= "3:35" %></span>
@@ -126,7 +132,7 @@
               <span class="jam-value"><%= jam.file.filename %></span>
             </div>
             <div class="column">
-              <span class="jam-value"><%= "MIX" %></span>
+              <span class="jam-value"><%= jam.jam_type %></span>
             </div>
             <div class="column">
               <span class="jam-value"><%= "3:35" %></span>

--- a/app/views/rooms/show.html.erb
+++ b/app/views/rooms/show.html.erb
@@ -38,6 +38,24 @@
             </span>
           </li>
           <li>
+            <span class="jam-attribute jam-attribute-bpm">
+              <span class="jam-key"><i class="fas fa-music"></i> Song Key: </span>
+              <span class="jam-value"><%= @current_jam.song_key_list %></span>
+            </span>
+          </li>
+          <li>
+            <span class="jam-attribute jam-attribute-bpm">
+              <span class="jam-key"><i class="fas fa-users"></i> Could Use: </span>
+              <span class="jam-value"><%= @current_jam.could_use_list %></span>
+            </span>
+          </li>
+          <li>
+            <span class="jam-attribute jam-attribute-bpm">
+              <span class="jam-key"><i class="fas fa-compact-disc"></i></i> Styles: </span>
+              <span class="jam-value"><%= @current_jam.style_list %></span>
+            </span>
+          </li>
+          <li>
             <span class="jam-attribute jam-attribute-user">
               <span class="jam-key"><i class="far fa-user"></i> User: </span>
               <span class="jam-value"><%= jam_user(@current_jam) %></span>
@@ -77,7 +95,7 @@
           Filename
         </div>
         <div class="column">
-          <i class="fas fa-compact-disc"></i>
+          <i class="fas fa-file-audio"></i>
         </div>
         <div class="column">
           <i class="far fa-clock"></i>
@@ -129,45 +147,7 @@
   </div>
 </section>
 
-<div id="upload-track-modal" class="modal">
-  <div class="modal-background"></div>
-  <div class="modal-card">
-    <%= form_with(model: @new_jam, url: [@room, @new_jam],  multipart: true,  local: true) do |form| %>
-      <header class="modal-card-head">
-        <p class="modal-card-title">Upload a Jam</p>
-        <button class="delete modal-close-button" aria-label="close"></button>
-      </header>
-      <section class="modal-card-body">
-        <div class="field">
-          <label class="label">BPM:</label>
-          <%= form.text_field :bpm, class: "input" %>
-        </div>
-        <div class="field">
-          <div id="file-upload-field" class="file has-name">
-            <label class="file-label">
-              <%= form.file_field :file, class: "file-input", accept: "audio/*" %>
-              <span class="file-cta">
-                <span class="file-icon">
-                  <i class="fas fa-upload"></i>
-                </span>
-                <span class="file-label">
-                  Choose a file...
-                </span>
-              </span>
-              <span class="file-name">
-                No file selected
-              </span>
-            </label>
-          </div>
-        </div>
-      </section>
-      <footer class="modal-card-foot">
-        <%= submit_tag "Upload", class: "button is-success" %>
-        <button class="button modal-close-button">Cancel</button>
-      </footer>
-    <% end %>
-  </div>
-</div>
+<%= render 'upload_track_modal' %>
 
 <script>
   const uploadJamButton = document.querySelector('button#upload-jam-button');

--- a/db/migrate/20200404044313_acts_as_taggable_on_migration.acts_as_taggable_on_engine.rb
+++ b/db/migrate/20200404044313_acts_as_taggable_on_migration.acts_as_taggable_on_engine.rb
@@ -1,0 +1,37 @@
+# This migration comes from acts_as_taggable_on_engine (originally 1)
+if ActiveRecord.gem_version >= Gem::Version.new('5.0')
+  class ActsAsTaggableOnMigration < ActiveRecord::Migration[4.2]; end
+else
+  class ActsAsTaggableOnMigration < ActiveRecord::Migration; end
+end
+ActsAsTaggableOnMigration.class_eval do
+  def self.up
+    create_table ActsAsTaggableOn.tags_table do |t|
+      t.string :name
+      t.timestamps
+    end
+
+    create_table ActsAsTaggableOn.taggings_table do |t|
+      t.references :tag, foreign_key: { to_table: ActsAsTaggableOn.tags_table }
+
+      # You should make sure that the column created is
+      # long enough to store the required class names.
+      t.references :taggable, polymorphic: true
+      t.references :tagger, polymorphic: true
+
+      # Limit is created to prevent MySQL error on index
+      # length for MyISAM table type: http://bit.ly/vgW2Ql
+      t.string :context, limit: 128
+
+      t.datetime :created_at
+    end
+
+    add_index ActsAsTaggableOn.taggings_table, :tag_id
+    add_index ActsAsTaggableOn.taggings_table, [:taggable_id, :taggable_type, :context], name: 'taggings_taggable_context_idx'
+  end
+
+  def self.down
+    drop_table ActsAsTaggableOn.taggings_table
+    drop_table ActsAsTaggableOn.tags_table
+  end
+end

--- a/db/migrate/20200404044314_add_missing_unique_indices.acts_as_taggable_on_engine.rb
+++ b/db/migrate/20200404044314_add_missing_unique_indices.acts_as_taggable_on_engine.rb
@@ -1,0 +1,26 @@
+# This migration comes from acts_as_taggable_on_engine (originally 2)
+if ActiveRecord.gem_version >= Gem::Version.new('5.0')
+  class AddMissingUniqueIndices < ActiveRecord::Migration[4.2]; end
+else
+  class AddMissingUniqueIndices < ActiveRecord::Migration; end
+end
+AddMissingUniqueIndices.class_eval do
+  def self.up
+    add_index ActsAsTaggableOn.tags_table, :name, unique: true
+
+    remove_index ActsAsTaggableOn.taggings_table, :tag_id if index_exists?(ActsAsTaggableOn.taggings_table, :tag_id)
+    remove_index ActsAsTaggableOn.taggings_table, name: 'taggings_taggable_context_idx'
+    add_index ActsAsTaggableOn.taggings_table,
+              [:tag_id, :taggable_id, :taggable_type, :context, :tagger_id, :tagger_type],
+              unique: true, name: 'taggings_idx'
+  end
+
+  def self.down
+    remove_index ActsAsTaggableOn.tags_table, :name
+
+    remove_index ActsAsTaggableOn.taggings_table, name: 'taggings_idx'
+
+    add_index ActsAsTaggableOn.taggings_table, :tag_id unless index_exists?(ActsAsTaggableOn.taggings_table, :tag_id)
+    add_index ActsAsTaggableOn.taggings_table, [:taggable_id, :taggable_type, :context], name: 'taggings_taggable_context_idx'
+  end
+end

--- a/db/migrate/20200404044315_add_taggings_counter_cache_to_tags.acts_as_taggable_on_engine.rb
+++ b/db/migrate/20200404044315_add_taggings_counter_cache_to_tags.acts_as_taggable_on_engine.rb
@@ -1,0 +1,20 @@
+# This migration comes from acts_as_taggable_on_engine (originally 3)
+if ActiveRecord.gem_version >= Gem::Version.new('5.0')
+  class AddTaggingsCounterCacheToTags < ActiveRecord::Migration[4.2]; end
+else
+  class AddTaggingsCounterCacheToTags < ActiveRecord::Migration; end
+end
+AddTaggingsCounterCacheToTags.class_eval do
+  def self.up
+    add_column ActsAsTaggableOn.tags_table, :taggings_count, :integer, default: 0
+
+    ActsAsTaggableOn::Tag.reset_column_information
+    ActsAsTaggableOn::Tag.find_each do |tag|
+      ActsAsTaggableOn::Tag.reset_counters(tag.id, ActsAsTaggableOn.taggings_table)
+    end
+  end
+
+  def self.down
+    remove_column ActsAsTaggableOn.tags_table, :taggings_count
+  end
+end

--- a/db/migrate/20200404044316_add_missing_taggable_index.acts_as_taggable_on_engine.rb
+++ b/db/migrate/20200404044316_add_missing_taggable_index.acts_as_taggable_on_engine.rb
@@ -1,0 +1,15 @@
+# This migration comes from acts_as_taggable_on_engine (originally 4)
+if ActiveRecord.gem_version >= Gem::Version.new('5.0')
+  class AddMissingTaggableIndex < ActiveRecord::Migration[4.2]; end
+else
+  class AddMissingTaggableIndex < ActiveRecord::Migration; end
+end
+AddMissingTaggableIndex.class_eval do
+  def self.up
+    add_index ActsAsTaggableOn.taggings_table, [:taggable_id, :taggable_type, :context], name: 'taggings_taggable_context_idx'
+  end
+
+  def self.down
+    remove_index ActsAsTaggableOn.taggings_table, name: 'taggings_taggable_context_idx'
+  end
+end

--- a/db/migrate/20200404044317_change_collation_for_tag_names.acts_as_taggable_on_engine.rb
+++ b/db/migrate/20200404044317_change_collation_for_tag_names.acts_as_taggable_on_engine.rb
@@ -1,0 +1,15 @@
+# This migration comes from acts_as_taggable_on_engine (originally 5)
+# This migration is added to circumvent issue #623 and have special characters
+# work properly
+if ActiveRecord.gem_version >= Gem::Version.new('5.0')
+  class ChangeCollationForTagNames < ActiveRecord::Migration[4.2]; end
+else
+  class ChangeCollationForTagNames < ActiveRecord::Migration; end
+end
+ChangeCollationForTagNames.class_eval do
+  def up
+    if ActsAsTaggableOn::Utils.using_mysql?
+      execute("ALTER TABLE #{ActsAsTaggableOn.tags_table} MODIFY name varchar(255) CHARACTER SET utf8 COLLATE utf8_bin;")
+    end
+  end
+end

--- a/db/migrate/20200404044318_add_missing_indexes_on_taggings.acts_as_taggable_on_engine.rb
+++ b/db/migrate/20200404044318_add_missing_indexes_on_taggings.acts_as_taggable_on_engine.rb
@@ -1,0 +1,23 @@
+# This migration comes from acts_as_taggable_on_engine (originally 6)
+if ActiveRecord.gem_version >= Gem::Version.new('5.0')
+  class AddMissingIndexesOnTaggings < ActiveRecord::Migration[4.2]; end
+else
+  class AddMissingIndexesOnTaggings < ActiveRecord::Migration; end
+end
+AddMissingIndexesOnTaggings.class_eval do
+  def change
+    add_index ActsAsTaggableOn.taggings_table, :tag_id unless index_exists? ActsAsTaggableOn.taggings_table, :tag_id
+    add_index ActsAsTaggableOn.taggings_table, :taggable_id unless index_exists? ActsAsTaggableOn.taggings_table, :taggable_id
+    add_index ActsAsTaggableOn.taggings_table, :taggable_type unless index_exists? ActsAsTaggableOn.taggings_table, :taggable_type
+    add_index ActsAsTaggableOn.taggings_table, :tagger_id unless index_exists? ActsAsTaggableOn.taggings_table, :tagger_id
+    add_index ActsAsTaggableOn.taggings_table, :context unless index_exists? ActsAsTaggableOn.taggings_table, :context
+
+    unless index_exists? ActsAsTaggableOn.taggings_table, [:tagger_id, :tagger_type]
+      add_index ActsAsTaggableOn.taggings_table, [:tagger_id, :tagger_type]
+    end
+
+    unless index_exists? ActsAsTaggableOn.taggings_table, [:taggable_id, :taggable_type, :tagger_id, :context], name: 'taggings_idy'
+      add_index ActsAsTaggableOn.taggings_table, [:taggable_id, :taggable_type, :tagger_id, :context], name: 'taggings_idy'
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_04_02_223118) do
+ActiveRecord::Schema.define(version: 2020_04_04_044318) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -100,6 +100,33 @@ ActiveRecord::Schema.define(version: 2020_04_02_223118) do
     t.index ["user_id"], name: "index_rooms_on_user_id"
   end
 
+  create_table "taggings", id: :serial, force: :cascade do |t|
+    t.integer "tag_id"
+    t.string "taggable_type"
+    t.integer "taggable_id"
+    t.string "tagger_type"
+    t.integer "tagger_id"
+    t.string "context", limit: 128
+    t.datetime "created_at"
+    t.index ["context"], name: "index_taggings_on_context"
+    t.index ["tag_id", "taggable_id", "taggable_type", "context", "tagger_id", "tagger_type"], name: "taggings_idx", unique: true
+    t.index ["tag_id"], name: "index_taggings_on_tag_id"
+    t.index ["taggable_id", "taggable_type", "context"], name: "taggings_taggable_context_idx"
+    t.index ["taggable_id", "taggable_type", "tagger_id", "context"], name: "taggings_idy"
+    t.index ["taggable_id"], name: "index_taggings_on_taggable_id"
+    t.index ["taggable_type"], name: "index_taggings_on_taggable_type"
+    t.index ["tagger_id", "tagger_type"], name: "index_taggings_on_tagger_id_and_tagger_type"
+    t.index ["tagger_id"], name: "index_taggings_on_tagger_id"
+  end
+
+  create_table "tags", id: :serial, force: :cascade do |t|
+    t.string "name"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+    t.integer "taggings_count", default: 0
+    t.index ["name"], name: "index_tags_on_name", unique: true
+  end
+
   create_table "users", force: :cascade do |t|
     t.string "display_name", default: ""
     t.citext "email", default: "", null: false
@@ -129,4 +156,5 @@ ActiveRecord::Schema.define(version: 2020_04_02_223118) do
   add_foreign_key "jams", "users"
   add_foreign_key "notifications", "users"
   add_foreign_key "rooms", "users"
+  add_foreign_key "taggings", "tags"
 end

--- a/spec/factories/jam_factory.rb
+++ b/spec/factories/jam_factory.rb
@@ -2,8 +2,12 @@
 
 FactoryBot.define do
   factory :jam do
-    bpm { '120' }
     file { fixture_file_upload(Rails.root.join('spec', 'support', 'assets', 'test.mp3'), 'audio/mpeg') }
+    bpm { '120' }
+    song_key_list { ['A Major'] }
+    style_list { ['Electronic', 'Lofi'] }
+    could_use_list { ['Bass', 'Drums'] }
+
     room
     user
   end

--- a/spec/factories/jam_factory.rb
+++ b/spec/factories/jam_factory.rb
@@ -3,8 +3,9 @@
 FactoryBot.define do
   factory :jam do
     file { fixture_file_upload(Rails.root.join('spec', 'support', 'assets', 'test.mp3'), 'audio/mpeg') }
-    bpm { '120' }
+    bpm_list { ['120'] }
     song_key_list { ['A Major'] }
+    jam_type_list { ['MIX'] }
     style_list { ['Electronic', 'Lofi'] }
     could_use_list { ['Bass', 'Drums'] }
 

--- a/spec/models/jam_spec.rb
+++ b/spec/models/jam_spec.rb
@@ -19,6 +19,11 @@ RSpec.describe Jam, type: :model do
       expect(jam).to_not be_valid
       expect(jam.errors[:file]).to include("must be an audio file")
     end
+
+    it 'does not allow jam type that is not MIX or SOLO' do
+      jam.jam_type_list = ['INVALID']
+      expect(jam).to_not be_valid
+    end
   end
 
   it 'creates an activity' do

--- a/spec/requests/controllers/jams_controller_spec.rb
+++ b/spec/requests/controllers/jams_controller_spec.rb
@@ -56,6 +56,29 @@ RSpec.describe JamsController, type: :request do
       end.to_not change{ user.notifications.count }
     end
 
+    context 'tagging' do
+      let(:jam_params) do
+        {
+          bpm: '100',
+          song_key_list: 'A Major',
+          style_list: 'Electronic, Lofi',
+          could_use_list: 'Bass, Guitar, Vocals',
+          file: file }
+      end
+      let(:uploaded_jam) { room.reload.jams.first }
+
+      let(:action) { post room_jams_path(room), params: { jam: jam_params } }
+
+      it 'allows for setting bpm' do
+        action
+
+        expect(uploaded_jam.bpm).to eq '100'
+        expect(uploaded_jam.song_key_list).to include('A Major')
+        expect(uploaded_jam.style_list).to include('Electronic', 'Lofi')
+        expect(uploaded_jam.could_use_list).to include('Bass', 'Guitar', 'Vocals')
+      end
+    end
+
     context "with an invalid file" do
       let(:file) { fixture_file_upload('spec/support/assets/invalid_file.txt') }
 

--- a/spec/requests/controllers/jams_controller_spec.rb
+++ b/spec/requests/controllers/jams_controller_spec.rb
@@ -60,7 +60,8 @@ RSpec.describe JamsController, type: :request do
       let(:jam_params) do
         {
           bpm: '100',
-          song_key_list: 'A Major',
+          song_key: 'A Major',
+          jam_type: 'MIX',
           style_list: 'Electronic, Lofi',
           could_use_list: 'Bass, Guitar, Vocals',
           file: file }
@@ -69,11 +70,12 @@ RSpec.describe JamsController, type: :request do
 
       let(:action) { post room_jams_path(room), params: { jam: jam_params } }
 
-      it 'allows for setting bpm' do
+      it 'uploads a file with given tags' do
         action
 
         expect(uploaded_jam.bpm).to eq '100'
-        expect(uploaded_jam.song_key_list).to include('A Major')
+        expect(uploaded_jam.song_key).to include('A Major')
+        expect(uploaded_jam.jam_type).to include('MIX')
         expect(uploaded_jam.style_list).to include('Electronic', 'Lofi')
         expect(uploaded_jam.could_use_list).to include('Bass', 'Guitar', 'Vocals')
       end

--- a/spec/requests/controllers/jams_controller_spec.rb
+++ b/spec/requests/controllers/jams_controller_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe JamsController, type: :request do
     before { sign_in(user) }
 
     let(:file) { fixture_file_upload('spec/support/assets/test.mp3') }
-    let(:jam_params) { { bpm: '100', file: file } }
+    let(:jam_params) { { bpm_list: '100', file: file } }
     let(:uploaded_jam) { room.reload.jams.first }
 
     let(:action) { post room_jams_path(room), params: { jam: jam_params } }
@@ -59,16 +59,14 @@ RSpec.describe JamsController, type: :request do
     context 'tagging' do
       let(:jam_params) do
         {
-          bpm: '100',
-          song_key: 'A Major',
-          jam_type: 'MIX',
+          bpm_list: '100',
+          song_key_list: 'A Major',
+          jam_type_list: 'MIX',
           style_list: 'Electronic, Lofi',
           could_use_list: 'Bass, Guitar, Vocals',
-          file: file }
+          file: file,
+        }
       end
-      let(:uploaded_jam) { room.reload.jams.first }
-
-      let(:action) { post room_jams_path(room), params: { jam: jam_params } }
 
       it 'uploads a file with given tags' do
         action

--- a/spec/system/home_page_spec.rb
+++ b/spec/system/home_page_spec.rb
@@ -68,18 +68,6 @@ RSpec.describe 'visiting the home page', type: :system do
         expect(page).to have_content('Signed out successfully')
       end
 
-      it 'allows a user to upload a jam', js: true do
-        room = create(:room)
-        visit room_path(room)
-        click_on 'Upload New Track'
-
-        fill_in :jam_bpm, with: '120', visible: true
-        attach_file :jam_file, 'spec/support/assets/test.mp3', make_visible: true
-        click_on 'Upload'
-
-        expect(page).to have_content('Jam successfully created!')
-      end
-
       context 'activity feed' do
         it 'allows user to view a jam they uploaded' do
           activity = create(:activity, :jam, user: user)

--- a/spec/system/jam_uploading_spec.rb
+++ b/spec/system/jam_uploading_spec.rb
@@ -23,17 +23,14 @@ RSpec.describe 'uploading jams', type: :system do
       attach_file :jam_file, 'spec/support/assets/test.mp3', make_visible: true
 
       fill_in :jam_bpm, with: '120'
-      fill_in :jam_song_key_list, with: 'A Major'
-      fill_in :jam_style_list, with: 'Electronic, Lofi'
-      fill_in :jam_could_use_list, with: 'Bass, Guitar, Vocals'
 
       click_on 'Upload'
 
       expect(page).to have_content('Jam successfully created!')
       expect(page).to have_content('120')
-      expect(page).to have_content('A Major')
-      expect(page).to have_content('Electronic')
-      expect(page).to have_content('Bass')
+
+      # Radio button defaults to MIX
+      expect(page).to have_content('MIX')
     end
   end
 end

--- a/spec/system/jam_uploading_spec.rb
+++ b/spec/system/jam_uploading_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'uploading jams', type: :system do
+  # TODO Remove when beta invite code feature is removed
+  before :each do
+    InviteCode.create(code: 'correct-code')
+    visit root_path
+    fill_in :beta_code, with: 'correct-code'
+    click_on 'Go'
+  end
+
+  context 'authenticated' do
+    let(:user) { create(:user) }
+    before(:each) { sign_in user }
+
+    it 'allows a user to upload a jam', js: true do
+      room = create(:room)
+      visit room_path(room)
+      click_on 'Upload New Track'
+
+      attach_file :jam_file, 'spec/support/assets/test.mp3', make_visible: true
+
+      fill_in :jam_bpm, with: '120'
+      fill_in :jam_song_key_list, with: 'A Major'
+      fill_in :jam_style_list, with: 'Electronic, Lofi'
+      fill_in :jam_could_use_list, with: 'Bass, Guitar, Vocals'
+
+      click_on 'Upload'
+
+      expect(page).to have_content('Jam successfully created!')
+      expect(page).to have_content('120')
+      expect(page).to have_content('A Major')
+      expect(page).to have_content('Electronic')
+      expect(page).to have_content('Bass')
+    end
+  end
+end

--- a/spec/system/jam_uploading_spec.rb
+++ b/spec/system/jam_uploading_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe 'uploading jams', type: :system do
 
       attach_file :jam_file, 'spec/support/assets/test.mp3', make_visible: true
 
-      fill_in :jam_bpm, with: '120'
+      fill_in :jam_bpm_list, with: '120'
 
       click_on 'Upload'
 


### PR DESCRIPTION
This PR adds ActsAsTaggableOn tag support for the jam attributes bpm, jam type, song key, could use, and style.

`acts_as_taggable_on` has the ability to [set contexts](https://github.com/tomekr/jamroulette/compare/acts-as-taggable-on?expand=1#diff-3bd7bdbbeff20cf2bafd54b4b0707dc4) that in a way act as categories. With these contexts set, you can do things like find [relationships](https://github.com/mbleigh/acts-as-taggable-on#relationships):

```
@jam.style_list # => ["Electronic", "Lofi"]

@jam.find_related_styles # => [<Jam name="all_about_the_drop.mp3">, <Jam name="oontz.mp3">]
```

<img width="662" alt="upload-form" src="https://user-images.githubusercontent.com/723637/78503604-54503e00-772d-11ea-8c60-0356c0b06d2f.png">

<img width="361" alt="attributes" src="https://user-images.githubusercontent.com/723637/78503538-d3914200-772c-11ea-99af-99bb3f9c4596.png">
