### PR TITLE
Visit instead of join random room

### DIFF
--- a/app/views/layouts/_navbar.html.erb
+++ b/app/views/layouts/_navbar.html.erb
@@ -38,12 +38,20 @@
         <div class="navbar-item">
           <div class="buttons">
           <% if user_signed_in? %>
-            <button class="button is-primary is-inverted create-room-button">
-              <span class="icon">
-                <i class="fas fa-plus-circle"></i>
-              </span>
-              <span>Create Room</span>
-            </button>
+            <% unless current_page?(home_path) %>
+              <%= link_to(random_rooms_path, class: "button is-primary is-inverted") do %>
+                <span class="icon">
+                  <i class="fas fa-door-open"></i>
+                </span>
+                <span>Random Room</span>
+              <% end %>
+              <button class="button is-primary is-inverted create-room-button">
+                <span class="icon">
+                  <i class="fas fa-plus-circle"></i>
+                </span>
+                <span>Create Room</span>
+              </button>
+            <% end %>
             <%= link_to(destroy_user_session_path, method: :delete,  class: "button is-primary is-inverted") do %>
               <span class="icon">
                 <i class="fas fa-user"></i>

--- a/app/views/static/index.html.erb
+++ b/app/views/static/index.html.erb
@@ -3,17 +3,17 @@
     <div class="container">
       <section class="section">
         <h1 class="title">
-          Jam Roulette. Add your part.
+          Jam Roulette
         </h1>
         <h2 class="subtitle">
-          Join a room to start building up a track or start your own.
+          Download a track. Add something. Upload it back.
         </h2>
 
         <%= link_to(random_rooms_path, class: "button is-primary is-inverted") do %>
           <span class="icon">
             <i class="fas fa-door-open"></i>
           </span>
-          <span>Join a random room</span>
+          <span>Visit a random room</span>
         <% end %>
 
         <button class="button is-primary is-inverted create-room-button">

--- a/spec/system/home_page_spec.rb
+++ b/spec/system/home_page_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe 'visiting the home page', type: :system do
 
       visit home_path
 
-      click_link('Join a random room')
+      click_link('Visit a random room')
 
       expect(page).to have_content('random-room')
     end


### PR DESCRIPTION
Change wording since "Join a random room" implies some sort of state change. Also, hide the random room and create room buttons on the home page.