### PR TITLE
Send audio file duration when uploading a Jam

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 language: ruby
+addons:
+  chrome: stable
 services:
   - postgresql
 before_install:

--- a/app/controllers/jams_controller.rb
+++ b/app/controllers/jams_controller.rb
@@ -21,7 +21,7 @@ class JamsController < ApplicationController
 
   def jam_params
     params.require(:jam).permit(
-      :file, :bpm_list, :song_key_list,
+      :file, :bpm_list, :song_key_list, :duration_list,
       :jam_type_list, :style_list, :could_use_list
     )
   end

--- a/app/helpers/rooms_helper.rb
+++ b/app/helpers/rooms_helper.rb
@@ -2,4 +2,12 @@ module RoomsHelper
   def jam_user(jam)
     jam.user ? jam.user.display_name : "Anonymous"
   end
+
+  def format_duration(duration_in_seconds)
+    if duration_in_seconds.present?
+      Time.at(duration_in_seconds.to_i).utc.strftime("%M:%S")
+    else
+      'Unavailable'
+    end
+  end
 end

--- a/app/javascript/packs/notification_feed.ts
+++ b/app/javascript/packs/notification_feed.ts
@@ -1,10 +1,14 @@
 document.addEventListener("DOMContentLoaded", () => {
+  const feed = document.querySelector('#notifications') as HTMLElement
+  const countTag = feed.querySelector(".tag") as HTMLSpanElement
+
+  if (countTag.innerText != "0") {
+    countTag.classList.replace("is-primary", "is-danger")
+  }
+
   // Show modal when a "Create room" button is clicked
   document.querySelector("#notifications").addEventListener('click', (event) => {
-    console.log('clicked')
-
     // Toggle feed list
-    const feed = document.querySelector('#notifications') as HTMLElement
     feed.classList.toggle('is-active')
 
     // Remove counter tag

--- a/app/models/jam.rb
+++ b/app/models/jam.rb
@@ -2,7 +2,7 @@
 
 class Jam < ApplicationRecord
   include Trackable
-  acts_as_taggable_on :bpm, :song_key, :jam_type, :styles, :could_use
+  acts_as_taggable_on :bpm, :song_key, :jam_type, :duration, :styles, :could_use
 
   belongs_to :room
   belongs_to :user
@@ -25,6 +25,10 @@ class Jam < ApplicationRecord
 
   def jam_type
     jam_type_list.first
+  end
+
+  def duration
+    duration_list.first
   end
 
   private

--- a/app/views/layouts/_navbar.html.erb
+++ b/app/views/layouts/_navbar.html.erb
@@ -14,24 +14,15 @@
       <div class="navbar-end">
         <div class="navbar-item">
           <% if user_signed_in? %>
-            <% if has_unread_notifications?(current_user) %>
-              <div id="notifications" class="dropdown" aria-haspopup="true" aria-controls="dropdown-menu" data-user-id="<%= current_user.id %>">
-                <div class="dropdown-trigger">
-                  <span class="tag is-danger is-small notification-counter"><%= current_user.notifications.unread.count %></span>
-                  <span class="icon">
-                    <i class="far fa-bell"></i>
-                  </span>
-                </div>
-                <%= render 'shared/notifications' %>
-              </div>
-            <% else %>
-              <div>
-                <span class="tag is-primary is-small notification-counter">0</span>
+            <div id="notifications" class="dropdown" aria-haspopup="true" aria-controls="dropdown-menu" data-user-id="<%= current_user.id %>">
+              <div class="dropdown-trigger">
+                <span class="tag is-primary is-small notification-counter"><%= current_user.notifications.unread.count %></span>
                 <span class="icon">
                   <i class="far fa-bell"></i>
                 </span>
               </div>
-            <% end %>
+              <%= render 'shared/notifications' %>
+            </div>
           <% end %>
         </div>
 

--- a/app/views/rooms/_upload_track_modal.html.erb
+++ b/app/views/rooms/_upload_track_modal.html.erb
@@ -26,6 +26,7 @@
               </span>
             </label>
           </div>
+          <%= form.hidden_field(:duration_list) %>
         </div>
 
         <div id="jam-type-buttons" class="field has-addons">

--- a/app/views/rooms/show.html.erb
+++ b/app/views/rooms/show.html.erb
@@ -34,7 +34,7 @@
           <li>
             <span class="jam-attribute jam-attribute-length">
               <span class="jam-key"><i class="far fa-clock"></i> Length: </span>
-              <span class="jam-value"><%= "3:35" %></span>
+              <span class="jam-value"><%= format_duration(@current_jam.duration) %></span>
             </span>
           </li>
           <li>
@@ -135,7 +135,7 @@
               <span class="jam-value"><%= jam.jam_type %></span>
             </div>
             <div class="column">
-              <span class="jam-value"><%= "3:35" %></span>
+              <span class="jam-value"><%= format_duration(jam.duration) %></span>
             </div>
             <div class="column">
               <span class="jam-value"><%= jam.bpm %></span>
@@ -181,12 +181,24 @@
     });
   }
   
-  // For changing the name in the file upload element
+  // Handle audio file upload
   const fileInput = document.querySelector('#file-upload-field input[type=file]');
-  fileInput.onchange = () => {
+
+  fileInput.addEventListener('change', () => {
     if (fileInput.files.length > 0) {
       const fileName = document.querySelector('#file-upload-field .file-name');
-      fileName.textContent = fileInput.files[0].name;
+      const file = fileInput.files[0]
+      fileName.textContent = file.name;
+
+      const durationInput = document.querySelector('#jam_duration_list');
+      const audioContext = new (window.AudioContext || window.webkitAudioContext)();
+  
+      file.arrayBuffer().then(fileBuffer => {
+        audioContext.decodeAudioData(fileBuffer).then(decodeAudioData => {
+          const duration = decodeAudioData.duration;
+          durationInput.value = parseInt(duration);
+        })
+      });
     }
-  }
+  });
 </script>

--- a/app/views/rooms/show.html.erb
+++ b/app/views/rooms/show.html.erb
@@ -156,49 +156,49 @@
 <%= render 'upload_track_modal' %>
 
 <script>
-  const uploadJamButton = document.querySelector('button#upload-jam-button');
-  uploadJamButton.onclick = (event) => {
-    event.preventDefault();
-  
-    const modal = document.querySelector('#upload-track-modal');
-    const html = document.querySelector('html');
-    modal.classList.add('is-active');
-    html.classList.add('is-clipped');
-  
-    const closeFunction = (e) => {
-      e.preventDefault();
-      modal.classList.remove('is-active');
-      html.classList.remove('is-clipped');
-    };
-  
-    // Give focus to bpm input element
-    modal.querySelector('#jam_bpm').focus();
+  document.addEventListener("DOMContentLoaded", () => {
+    const uploadTrackModal = document.querySelector('#upload-track-modal');
 
-    modal.querySelector('.modal-background').addEventListener('click', closeFunction);
-  
-    modal.querySelectorAll("button.modal-close-button").forEach(element => {
-      element.addEventListener('click', closeFunction);
-    });
-  }
-  
-  // Handle audio file upload
-  const fileInput = document.querySelector('#file-upload-field input[type=file]');
+    const uploadJamButton = document.querySelector('button#upload-jam-button');
+    uploadJamButton.onclick = (event) => {
+      event.preventDefault();
+      
+      uploadTrackModal.classList.add('is-active');
+    
+      const closeFunction = (e) => {
+        e.preventDefault();
+        uploadTrackModal.classList.remove('is-active');
+      };
 
-  fileInput.addEventListener('change', () => {
-    if (fileInput.files.length > 0) {
-      const fileName = document.querySelector('#file-upload-field .file-name');
-      const file = fileInput.files[0]
-      fileName.textContent = file.name;
-
-      const durationInput = document.querySelector('#jam_duration_list');
-      const audioContext = new (window.AudioContext || window.webkitAudioContext)();
-  
-      file.arrayBuffer().then(fileBuffer => {
-        audioContext.decodeAudioData(fileBuffer).then(decodeAudioData => {
-          const duration = decodeAudioData.duration;
-          durationInput.value = parseInt(duration);
-        })
+      uploadTrackModal.querySelector('.modal-background').addEventListener('click', closeFunction);
+    
+      uploadTrackModal.querySelectorAll("button.modal-close-button").forEach(element => {
+        element.addEventListener('click', closeFunction);
       });
     }
+    
+    // Handle audio file upload
+    const fileInput = document.querySelector('#file-upload-field input[type=file]');
+
+    fileInput.addEventListener('change', () => {
+      if (fileInput.files.length > 0) {
+        const fileName = document.querySelector('#file-upload-field .file-name');
+        const file = fileInput.files[0]
+        fileName.textContent = file.name;
+
+        const durationInput = document.querySelector('#jam_duration_list');
+        const audioContext = new (window.AudioContext || window.webkitAudioContext)();
+    
+        file.arrayBuffer().then(fileBuffer => {
+          audioContext.decodeAudioData(fileBuffer).then(decodeAudioData => {
+            const duration = decodeAudioData.duration;
+            durationInput.value = parseInt(duration);
+          })
+        });
+
+        // Send focus to bpm input
+        uploadTrackModal.querySelector('#jam_bpm_list').focus();
+      }
+    });
   });
 </script>

--- a/app/views/shared/_notifications.html.erb
+++ b/app/views/shared/_notifications.html.erb
@@ -7,6 +7,10 @@
           <%= link_to notification.target.room.name, room_path(notification.target.room)%>
         </div>
       <% end %>
+    <% else %>
+      <div class="dropdown-item">
+        No new notifications
+      </div>
     <% end %>
   </div>
 </div>

--- a/spec/factories/jam_factory.rb
+++ b/spec/factories/jam_factory.rb
@@ -10,6 +10,7 @@ FactoryBot.define do
       bpm_list { ['120'] }
       song_key_list { ['A Major'] }
       jam_type_list { ['Mix'] }
+      duration_list { ['90'] }
       style_list { ['Electronic', 'Lofi'] }
       could_use_list { ['Bass', 'Drums'] }
     end

--- a/spec/helpers/rooms_helper_spec.rb
+++ b/spec/helpers/rooms_helper_spec.rb
@@ -19,4 +19,14 @@ RSpec.describe RoomsHelper, :type => :helper do
       end
     end
   end
+
+  describe "#format_duration" do
+    it 'returns duration in formated time' do
+      expect(helper.format_duration('90')).to eq('01:30')
+    end
+
+    it 'returns Unavailable if a duration does not exist' do
+      expect(helper.format_duration(nil)).to eq('Unavailable')
+    end
+  end
 end

--- a/spec/requests/controllers/jams_controller_spec.rb
+++ b/spec/requests/controllers/jams_controller_spec.rb
@@ -64,6 +64,7 @@ RSpec.describe JamsController, type: :request do
           jam_type_list: 'Mix',
           style_list: 'Electronic, Lofi',
           could_use_list: 'Bass, Guitar, Vocals',
+          duration_list: '95',
           file: file,
         }
       end
@@ -74,6 +75,7 @@ RSpec.describe JamsController, type: :request do
         expect(uploaded_jam.bpm).to eq '100'
         expect(uploaded_jam.song_key).to include('A Major')
         expect(uploaded_jam.jam_type).to include('Mix')
+        expect(uploaded_jam.duration).to include('95')
         expect(uploaded_jam.style_list).to include('Electronic', 'Lofi')
         expect(uploaded_jam.could_use_list).to include('Bass', 'Guitar', 'Vocals')
       end

--- a/spec/system/jam_uploading_spec.rb
+++ b/spec/system/jam_uploading_spec.rb
@@ -29,8 +29,12 @@ RSpec.describe 'uploading jams', type: :system do
       expect(page).to have_content('Jam successfully created!')
       expect(page).to have_content('120')
 
-      # Check that radio button defaults to Mix
-      expect(page).to have_content('Mix')
+      within('section#main') do
+        # Check that radio button defaulted to Mix
+        expect(page).to have_selector('span.jam-value', text: 'Mix')
+        # Fixture file is 1 second long
+        expect(page).to have_selector('span.jam-value', text: '00:01')
+      end
     end
 
     it 'moves jams that are not mixes straight to Supporting Jams section', js: true do


### PR DESCRIPTION
Utilize the Web Audio API to extract the audio file's duration and send it to the server to be stored as a `duration_list` tag on Jam.

https://github.com/tomekr/jamroulette/commit/3de106bc7070f6b69aa6e2c10897619199d0c053 and https://github.com/tomekr/jamroulette/commit/1f51183dfc803daf5a14f312560ccdb3f92a7141 also fix JS selector bugs that were in the app.