### PR TITLE
Use Active Storage Direct Upload to upload files directly to storage provider

### DIFF
--- a/app/javascript/controllers/jam_upload_controller.ts
+++ b/app/javascript/controllers/jam_upload_controller.ts
@@ -84,7 +84,7 @@ export default class extends Controller {
         this.extractDurationFromAudioFile(fileToUpload)
       }
 
-      const directUploadController = new DirectUploadController(this, fileToUpload)
+      const directUploadController = new DirectUploadController(this, fileToUpload, this.progressBarTarget)
       directUploadController.start()
 
       // Send focus to bpm input
@@ -101,10 +101,10 @@ class DirectUploadController {
   hiddenInput: HTMLInputElement
   progressBar: HTMLProgressElement
 
-  constructor(source: Controller, file: File) {
+  constructor(source: Controller, file: File, progressBar: HTMLProgressElement) {
     this.directUpload = new DirectUpload(file, source.fileFieldTarget.dataset.directUploadUrl, this)
     this.source = source
-    this.progressBar = this.source.progressBarTarget
+    this.progressBar = progressBar
     this.file = file
   }
 
@@ -137,6 +137,7 @@ class DirectUploadController {
   }
 
   private uploadRequestStarted(): void {
+    this.progressBar.value = 0
     this.progressBar.classList.remove(this.source.progressDoneClass)
     this.progressBar.classList.add(this.source.progressLoadingClass)
   }

--- a/app/javascript/controllers/jam_upload_controller.ts
+++ b/app/javascript/controllers/jam_upload_controller.ts
@@ -2,16 +2,22 @@ import { Controller } from "stimulus"
 import { DirectUpload } from "@rails/activestorage"
 
 export default class extends Controller {
-  static classes = ["active"]
-  static targets = ["uploadModal", "uploadForm", "fileField", "fileName", "durationField", "bpmField"]
+  static classes = ["active", "progressLoading", "progressDone"]
+  static targets = ["uploadModal", "uploadForm", "fileField", "fileName", "durationField", "bpmField", "progressBar"]
 
+  // Classes
   activeClass: string
+  progressLoadingClass: string
+  progressDoneClass: string
+
+  // Targets
   uploadFormTarget: HTMLFormElement
   uploadModalTarget: HTMLElement
   fileFieldTarget: HTMLInputElement
   durationFieldTarget: HTMLInputElement
   fileNameTarget: HTMLSpanElement
   bpmFieldTarget: HTMLInputElement
+  progressBarTarget: HTMLProgressElement
 
   toggleModal(event: CustomEvent) {
     this.uploadModalTarget.classList.toggle(this.activeClass)
@@ -22,21 +28,21 @@ export default class extends Controller {
     const upload = new DirectUpload(file, url)
     upload.create((error, blob) => {
       if (error) {
-        throw new Error('Direct Upload Error - ' + error);
+        throw new Error('Direct Upload Error - ' + error)
       } else {
         // Add an appropriately-named hidden input to the form with a
         // value of blob.signed_id so that the blob ids will be
         // transmitted in the normal upload flow
         const hiddenField = document.createElement('input')
-        hiddenField.setAttribute("type", "hidden");
-        hiddenField.setAttribute("value", blob.signed_id);
+        hiddenField.setAttribute("type", "hidden")
+        hiddenField.setAttribute("value", blob.signed_id)
         hiddenField.name = this.fileFieldTarget.name
         this.uploadFormTarget.appendChild(hiddenField)
       }
     })
   }
 
-  upload() {
+  submitForm() {
     this.uploadFormTarget.submit()
   }
 
@@ -78,10 +84,82 @@ export default class extends Controller {
         this.extractDurationFromAudioFile(fileToUpload)
       }
 
-      this.uploadFile(fileToUpload)
+      const directUploadController = new DirectUploadController(this, fileToUpload)
+      directUploadController.start()
 
       // Send focus to bpm input
       this.bpmFieldTarget.focus()
+    }
+  }
+}
+
+class DirectUploadController {
+  directUpload: DirectUpload
+  source: Controller
+  file: File
+  xhr: XMLHttpRequest
+  hiddenInput: HTMLInputElement
+  progressBar: HTMLProgressElement
+
+  constructor(source: Controller, file: File) {
+    this.directUpload = new DirectUpload(file, source.fileFieldTarget.dataset.directUploadUrl, this)
+    this.source = source
+    this.progressBar = this.source.progressBarTarget
+    this.file = file
+  }
+
+  public start(): void {
+    this.hiddenInput = this.createHiddenInput()
+    this.uploadRequestStarted()
+    this.directUpload.create((error, blob) => {
+      if (error) {
+        this.removeElement(this.hiddenInput)
+      } else {
+        this.hiddenInput.value = blob.signed_id
+        this.hiddenInput.name = this.source.fileFieldTarget.name
+      }
+    })
+  }
+
+  public directUploadWillStoreFileWithXHR(xhr): void {
+    this.bindProgressEvent(xhr)
+  }
+
+  private bindProgressEvent(xhr: XMLHttpRequest): void {
+    this.xhr = xhr
+    this.xhr.upload.addEventListener("progress", event =>
+      this.uploadRequestDidProgress(event)
+    )
+
+    this.xhr.addEventListener("load", () => {
+      this.uploadRequestFinished()
+    })
+  }
+
+  private uploadRequestStarted(): void {
+    this.progressBar.classList.remove(this.source.progressDoneClass)
+    this.progressBar.classList.add(this.source.progressLoadingClass)
+  }
+  private uploadRequestFinished(): void {
+    this.progressBar.classList.remove(this.source.progressLoadingClass)
+    this.progressBar.classList.add(this.source.progressDoneClass)
+  }
+
+  private uploadRequestDidProgress(event): void {
+    const progress = (event.loaded / event.total) * 100
+    this.progressBar.value = progress
+  }
+
+  private createHiddenInput(): HTMLInputElement {
+    const hiddenField = document.createElement('input')
+    hiddenField.setAttribute("type", "hidden")
+    this.source.uploadFormTarget.appendChild(hiddenField)
+    return hiddenField
+  }
+
+  private removeElement(element: HTMLElement): void {
+    if (element && element.parentNode) {
+      element.parentNode.removeChild(element)
     }
   }
 }

--- a/app/views/rooms/_upload_track_modal.html.erb
+++ b/app/views/rooms/_upload_track_modal.html.erb
@@ -13,7 +13,7 @@
         <div class="field">
           <div id="file-upload-field" class="file has-name">
             <label class="file-label">
-              <%= form.file_field :file, class: "file-input",
+              <%= form.file_field :file, class: "file-input", direct_upload: true,
                                   data: { "jam-upload-target": "fileField", "action": "change->jam-upload#fileSelected" },
                                   accept: "audio/*" %>
               <span class="file-cta">

--- a/app/views/rooms/_upload_track_modal.html.erb
+++ b/app/views/rooms/_upload_track_modal.html.erb
@@ -9,6 +9,7 @@
     </header>
 
     <section class="modal-card-body">
+      <progress class="progress is-primary" value="0" max="100" data-jam-upload-target="progressBar"></progress>
       <%= form_with(model: @new_jam, url: [@room, @new_jam],  multipart: true,  local: true, data: {"jam-upload-target": "uploadForm"}) do |form| %>
         <div class="field">
           <div id="file-upload-field" class="file has-name">
@@ -99,7 +100,7 @@
     </section>
 
     <footer class="modal-card-foot">
-      <%= submit_tag "Upload", class: "button is-primary", data: {"action": "click->jam-upload#upload"} %>
+      <%= submit_tag "Upload", class: "button is-primary", data: {"action": "click->jam-upload#submitForm"} %>
       <button class="button modal-close-button" data-action="click->jam-upload#toggleModal">Cancel</button>
     </footer>
   </div>

--- a/app/views/rooms/show.html.erb
+++ b/app/views/rooms/show.html.erb
@@ -1,4 +1,7 @@
-<div data-controller="jam-upload" data-jam-upload-active-class="is-active">
+<div data-controller="jam-upload"
+  data-jam-upload-active-class="is-active"
+  data-jam-upload-progress-loading-class="is-primary"
+  data-jam-upload-progress-done-class="is-success">
   <section class="section" id="room-header">
     <div id="breadcrumb">
       <%= "Home/#{@room.name}"%>

--- a/spec/requests/jams_request_spec.rb
+++ b/spec/requests/jams_request_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe 'Jams', type: :request do
 
       it 'restricts mime type on form field to audio/*' do
         get room_path(room)
-        expect(response.body).to include('accept="audio/*" type="file"')
+        expect(response.body).to include('accept="audio/*"')
       end
 
       context 'with a MIDI file' do


### PR DESCRIPTION
Adds a `DirectUploadController` that uses ActiveStorage's built in DirectUpload object. Based on this Typescript+Stimulus+ActiveStorage example https://github.com/VSM-Dave/rails_file_uploads

## Pre-Deploy Checklist:

- [x] Add [CORS configuration](https://edgeguides.rubyonrails.org/active_storage_overview.html#example-s3-cors-configuration) for Staging
- [ ] Add [CORS configuration](https://edgeguides.rubyonrails.org/active_storage_overview.html#example-s3-cors-configuration) for Production

![direct-upload-progress-bar](https://user-images.githubusercontent.com/723637/80506578-693e7c80-893b-11ea-9478-69e5b8cd2bb3.png)
