### PR TITLE
Fix double upload bug

### DIFF
--- a/app/javascript/controllers/jam_upload_controller.ts
+++ b/app/javascript/controllers/jam_upload_controller.ts
@@ -87,6 +87,9 @@ export default class extends Controller {
       const directUploadController = new DirectUploadController(this, fileToUpload, this.progressBarTarget)
       directUploadController.start()
 
+      // Remove the file from the form so it isn't uploaded again
+      this.fileFieldTarget.value = null
+
       // Send focus to bpm input
       this.bpmFieldTarget.focus()
     }

--- a/app/views/rooms/_upload_track_modal.html.erb
+++ b/app/views/rooms/_upload_track_modal.html.erb
@@ -10,7 +10,7 @@
 
     <section class="modal-card-body">
       <progress class="progress is-primary" value="0" max="100" data-jam-upload-target="progressBar"></progress>
-      <%= form_with(model: @new_jam, url: [@room, @new_jam],  multipart: true,  local: true, data: {"jam-upload-target": "uploadForm"}) do |form| %>
+      <%= form_with(model: @new_jam, url: [@room, @new_jam],  local: true, data: {"jam-upload-target": "uploadForm"}) do |form| %>
         <div class="field">
           <div id="file-upload-field" class="file has-name">
             <label class="file-label">


### PR DESCRIPTION
Null out the file field after uploading so that the file isn't also posted when the form is submitted. There is a small/slightly ambiguous reference to doing this in the Rails guides (https://edgeguides.rubyonrails.org/active_storage_overview.html#integrating-with-libraries-or-frameworks)