### PR TITLE
Remove New Relic gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -36,7 +36,6 @@ gem 'bootsnap', '>= 1.4.2', require: false
 
 group :production do
   gem 'aws-sdk-s3', '1.61.1'
-  gem 'newrelic_rpm'
   gem 'sentry-raven', '3.0.0'
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -163,7 +163,6 @@ GEM
     minitest (5.14.0)
     msgpack (1.3.1)
     multipart-post (2.1.1)
-    newrelic_rpm (6.10.0.364)
     nio4r (2.5.2)
     nokogiri (1.10.9)
       mini_portile2 (~> 2.4.0)
@@ -325,7 +324,6 @@ DEPENDENCIES
   jbuilder (~> 2.7)
   kaminari
   listen (>= 3.0.5, < 3.2)
-  newrelic_rpm
   pg (~> 1.2)
   pry-rails
   puma (~> 4.3)


### PR DESCRIPTION
Looks like New Relic doesn't offer a free tier and the trial has expired. Removing New Relic.